### PR TITLE
Renamed 'Änderungsprotokoll' to 'Update-Details' in Settings

### DIFF
--- a/src/locales/list/de-de.json
+++ b/src/locales/list/de-de.json
@@ -167,7 +167,7 @@
       "notifications": "Benachrichtigungen",
       "logout": "Abmelden",
       "viewSource": "Quellcode ansehen",
-      "changelog": "Änderungsprotokoll",
+      "changelog": "Update-Details",
       "window-settings": "Fenstereinstellungen",
       "privacy": "Privatsphäre"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated German localization: the “Changelog” item in the Settings drawer now displays as “Update-Details.”
  - Visible change only; no functional behavior modified.
  - Affects German-language interface wherever the Settings drawer label appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->