### PR TITLE
fix: only show viewReactions when reactions exist

### DIFF
--- a/src/components/message-pane/message-log-area/MessageLogArea.tsx
+++ b/src/components/message-pane/message-log-area/MessageLogArea.tsx
@@ -844,6 +844,8 @@ function MessageContextMenu(props: MessageContextMenuProps) {
   const showQuote = () => props.message.type === MessageType.CONTENT;
   const showReply = () => props.message.type === MessageType.CONTENT;
 
+  const hasReactions = () =>
+    props.message.reactions && Object.keys(props.message.reactions).length > 0;
   const hasContent = () => props.message.content;
   const isSelfMessage = () => account.user()?.id === props.message.createdBy.id;
   const showReportMessage = () => !isSelfMessage();
@@ -864,11 +866,16 @@ function MessageContextMenu(props: MessageContextMenuProps) {
       triggerClassName="floatingShowMore"
       {...props}
       items={[
-        {
-          icon: "face",
-          label: t("messageContextMenu.viewReactions"),
-          onClick: onViewReactionsClick,
-        },
+        ...(hasReactions()
+          ? [
+              {
+                icon: "face",
+                label: t("messageContextMenu.viewReactions"),
+                onClick: onViewReactionsClick,
+              },
+            ]
+          : []),
+
         {
           icon: "translate",
           label: "Translate",


### PR DESCRIPTION
Makes it so "View Reactions" button will only show when reactions exist, rather than permanently displaying on all messages.