### PR TITLE
I18n: message context menu

### DIFF
--- a/src/components/message-pane/message-log-area/MessageLogArea.tsx
+++ b/src/components/message-pane/message-log-area/MessageLogArea.tsx
@@ -877,12 +877,12 @@ function MessageContextMenu(props: MessageContextMenuProps) {
 
         {
           icon: "translate",
-          label: "Translate",
+          label: t("messageContextMenu.translateMessage"),
           onClick: onTranslateClick,
         },
         {
           icon: "mark_chat_unread",
-          label: "Mark Unread",
+          label: t("messageContextMenu.markUnread"),
           onClick: onMarkUnreadClick,
         },
         ...(showQuote()

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -507,7 +507,7 @@
       "more": "{{count}} more"
     },
     "deletedMessage": "Message was deleted.",
-    "dismissButton": "Dismiss.",
+    "dismissButton": "Dismiss",
     "editedAt": "Edited at {{time}}",
     "twitterEmbed": {
       "modalTitle": "Detailed Twitter Embed",

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -346,12 +346,22 @@
       "downloadAppNotice": "Download the Nerimity desktop app to use this feature without window tab focus."
     },
     "interface": {
+      "title": "Settings - Interface",
+      "customCSS": "Custom CSS",
+      "themes": "Themes",
+      "themesDescription": "Pick a preset theme or reset to default.",
+      "maintainers": "Maintainers",
+      "apply": "Apply",
+      "enableEruda": "Enable Eruda",
+      "enableErudaDescription": "Enable Eruda for debugging. Do not share any details with others.",
+      "enableOnce": "Enable Once",
       "blurEffect": "Blur Effect",
-      "blurEffectDescription": "Enables transparent blur effect. Disabled by default on mobile. Can cause performance issues.",
+      "blurEffectDescription": "Toggle blur effect on interface elements.",
+      "blurEffectWarning": "May reduce performance on some devices.",
       "disableAdvancedMarkupBar": "Disable Advanced Markup Bar",
-      "disableAdvancedMarkupBarDescription": "Disable advanced markup bar from text channels.",
+      "disableAdvancedMarkupBarDescription": "Prevent the advanced markup bar from appearing.",
       "customizeColors": "Customize Colors",
-      "customizeColorsDescription": "Customize the colors of the interface."
+      "customizeColorsDescription": "Edit colors for the current theme."
     }
   },
   "supportBlock": {
@@ -411,12 +421,14 @@
   "messageContextMenu": {
     "editMessage": "Edit Message",
     "deleteMessage": "Delete Message",
+    "translateMessage": "Translate",
     "copyMessage": "Copy Message",
     "copyId": "Copy ID",
     "viewReactions": "View Reactions",
     "quoteMessage": "Quote Message",
     "reportMessage": "Report Message",
-    "reply": "Reply"
+    "reply": "Reply",
+    "markUnread": "Mark Unread"
   },
   "profile": {
     "followButton": "Follow",

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -346,22 +346,12 @@
       "downloadAppNotice": "Download the Nerimity desktop app to use this feature without window tab focus."
     },
     "interface": {
-      "title": "Settings - Interface",
-      "customCSS": "Custom CSS",
-      "themes": "Themes",
-      "themesDescription": "Pick a preset theme or reset to default.",
-      "maintainers": "Maintainers",
-      "apply": "Apply",
-      "enableEruda": "Enable Eruda",
-      "enableErudaDescription": "Enable Eruda for debugging. Do not share any details with others.",
-      "enableOnce": "Enable Once",
       "blurEffect": "Blur Effect",
-      "blurEffectDescription": "Toggle blur effect on interface elements.",
-      "blurEffectWarning": "May reduce performance on some devices.",
+      "blurEffectDescription": "Enables transparent blur effect. Disabled by default on mobile. Can cause performance issues.",
       "disableAdvancedMarkupBar": "Disable Advanced Markup Bar",
-      "disableAdvancedMarkupBarDescription": "Prevent the advanced markup bar from appearing.",
+      "disableAdvancedMarkupBarDescription": "Disable advanced markup bar from text channels.",
       "customizeColors": "Customize Colors",
-      "customizeColorsDescription": "Edit colors for the current theme."
+      "customizeColorsDescription": "Customize the colors of the interface."
     }
   },
   "supportBlock": {

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -507,6 +507,7 @@
       "more": "{{count}} more"
     },
     "deletedMessage": "Message was deleted.",
+    "dismissButton": "Dismiss.",
     "editedAt": "Edited at {{time}}",
     "twitterEmbed": {
       "modalTitle": "Detailed Twitter Embed",

--- a/src/locales/list/uw-uw.json
+++ b/src/locales/list/uw-uw.json
@@ -512,6 +512,7 @@
       "more": "{{count}} mowe~"
     },
     "deletedMessage": "talky was poofed!",
+    "dismissButton": "go awae",
     "editedAt": "Edited at {{time}}~",
     "twitterEmbed": {
       "modalTitle": "Detaiwed Twittow Embed",

--- a/src/locales/list/uw-uw.json
+++ b/src/locales/list/uw-uw.json
@@ -370,12 +370,14 @@
   "messageContextMenu": {
     "editMessage": "edit talky",
     "deleteMessage": "poof talky",
+    "translateMessage": "owo wats dis?",
     "copyMessage": "copy talky",
     "copyId": "copy magic id",
     "viewReactions": "view reacties",
     "quoteMessage": "quote talky",
     "reportMessage": "wepowt talky",
-    "reply": "wepwy"
+    "reply": "wepwy",
+    "markUnread": "mawk unwead"
   },
   "profile": {
     "followButton": "fowwow uwu",


### PR DESCRIPTION
Changes translate & mark unread into translation strings rather than hard-coded strings.

Also updates uwu language (best language)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message context menu now uses localized labels for "Translate" and "Mark Unread" for a consistent user experience.

* **Chores**
  * Localization files updated (including en-GB and uw-uw) to add new message context menu keys and adjust related phrasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->