### PR TITLE
Fix "Reminder" entry borders + make translatable

### DIFF
--- a/src/components/settings/NotificationsSettings.tsx
+++ b/src/components/settings/NotificationsSettings.tsx
@@ -164,13 +164,14 @@ function NotificationSoundSelection() {
         label={t("settings.notifications.mention")}
         description={t("settings.notifications.mentionDescription")}
         borderTopRadius={false}
+        borderBottomRadius={false}
       >
         <NotificationSoundDropDown typeId="MESSAGE_MENTION" />
       </SettingsBlock>
       <SettingsBlock
         icon="calendar_today"
-        label="Reminder"
-        description="Notifications for reminders"
+        label={t("settings.notifications.reminder")}
+        description={t("settings.notifications.reminderDescription")}
         borderTopRadius={false}
       >
         <NotificationSoundDropDown typeId="REMINDER" />
@@ -206,7 +207,7 @@ function NotificationSoundDropDown(props: {
           setSelectedSounds({ ...selectedSounds(), [props.typeId]: sound }),
         label:
           sound === "nerimity-mute"
-            ? "Mute"
+            ? t("settings.notifications.mute")
             : capitalizeFirstLetter(sound.replaceAll("-", " ")),
         suffix: (
           <Show when={sound !== "nerimity-mute"}>

--- a/src/locales/list/be-xo.json
+++ b/src/locales/list/be-xo.json
@@ -322,6 +322,9 @@
       "messageDescription": "Гук, калі вы атрымлівайце паведамленьне.",
       "mention": "Згадваньне",
       "mentionDescription": "Гук, калі вас згадваюць.",
+      "reminder": "Нагады",
+      "reminderDescription": "Апавяшчэньні для нагадаў.",
+      "mute": "Без гуку",
       "inAppPreview": "Перадпрагляд у праґраме",
       "inAppPreviewDescription": "Паказваць усплываючыя паведамленьні ў праґраме.",
       "inAppPreviewModes": {

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -323,8 +323,11 @@
       "messageDescription": "Sound when receiving a message.",
       "mention": "Mention",
       "mentionDescription": "Sound when receiving a mention.",
+      "reminder": "Reminder",
+      "reminderDescription": "Notifications for reminders.",
       "inAppPreview": "In App Preview",
       "inAppPreviewDescription": "Display In App Notification popups.",
+      "mute": "Mute",
       "inAppPreviewModes": {
         "off": "Off",
         "mentionsOnly": "Mentions Only",


### PR DESCRIPTION
This PR fixes borders of the "Reminder" object in Settings > Notifications, while also adding a translation string for it to en-gb.json and be-xo.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification settings now use localized labels for “Reminder” and “Mute,” improving clarity across supported languages.
* **Style**
  * Minor UI polish in the notification sound selection for more consistent block styling.
* **Chores**
  * Added new localization keys for en-GB and be-XO: “Reminder,” “Reminder Description,” and “Mute,” expanding translation coverage in the Notifications settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->