### PR TITLE
feat: add themes support

### DIFF
--- a/src/common/themes.ts
+++ b/src/common/themes.ts
@@ -1,7 +1,6 @@
-import { StorageKeys, useLocalStorage } from "./localStorage";
-import { isHalloween } from "./worldEvents";
+import { StorageKeys, useLocalStorage, setStorageString } from "./localStorage";
 
-const DarkTheme = {
+const theme = {
   // Main
   "background-color": "hsl(216deg 9% 8%)",
   "pane-color": "hsl(216deg 8% 15%)",
@@ -33,49 +32,23 @@ const DarkTheme = {
   // Add multiple text colors, rather than using one.. E.G: message-text-color, channel-text-color, etc.
 };
 
-// const LightTheme = {
-// "background-color": "#f1f1f1",
-// "pane-color": "white",
-// "header-background-color": "white",
-// "header-background-color-blur-disabled": "white",
-// "text-color": "black",
-// };
-
-const theme = { ...DarkTheme };
-
-// if (isHalloween) {
-//   theme["primary-color"] = "#d76623";
-//   theme["primary-color-dark"] = "#241e1a";
-//   theme["alert-color"] = "#866ebf";
-//   theme["alert-color-dark"] = "#27242e";
-// }
-// if (isChristmas) {
-//   document.documentElement.style.setProperty("--primary-color", "#34a65f");
-//   document.documentElement.style.setProperty("--primary-color-dark", "#222c26");
-// }
-
-export { theme };
-
 type ThemeKey = keyof typeof theme;
 
-const [customColors, setCustomColors] = useLocalStorage<
-  Partial<Record<ThemeKey, string>>
->(StorageKeys.CUSTOM_COLORS, {});
+const [customColors, setCustomColors] = useLocalStorage<Partial<Record<ThemeKey, string>>>(
+  StorageKeys.CUSTOM_COLORS,
+  {}
+);
 
 const currentTheme = () => ({ ...theme, ...customColors() });
 
 export const updateTheme = () => {
   const newTheme = currentTheme();
-
   for (const key in newTheme) {
-    document.documentElement.style.setProperty(
-      `--${key}`,
-      newTheme[key as ThemeKey],
-    );
+    document.documentElement.style.setProperty(`--${key}`, newTheme[key as ThemeKey]);
   }
 };
 
-export const setThemeColor = (key: string, value?: string) => {
+export const setThemeColor = (key: ThemeKey, value?: string) => {
   if (value === undefined) {
     const temp = { ...customColors() };
     delete temp[key];
@@ -85,4 +58,53 @@ export const setThemeColor = (key: string, value?: string) => {
   }
   updateTheme();
 };
-export { currentTheme, customColors };
+
+// Theme presets
+export type ThemePreset = {
+  colors: Partial<Record<ThemeKey, string>>;
+  maintainers: string[];
+};
+
+export const themePresets: Record<string, ThemePreset> = {
+  Default: {
+    colors: {},
+    maintainers: ["Superkitten", "Asraye"],
+  },
+  AMOLED: {
+    colors: {
+      "background-color": "#000000",
+      "pane-color": "#000000",
+      "side-pane-color": "#0f0f0f",
+      "header-background-color": "#111111cc",
+      "header-background-color-blur-disabled": "#000000",
+      "tooltip-background-color": "#0a0a0a",
+      "primary-color": "#3a5a8f",
+      "alert-color": "#ff1f1f",
+      "warn-color": "#ff8c00",
+      "success-color": "#00ff77",
+      "success-color-dark": "#00cc44",
+      "primary-color-dark": "#ffffff",
+      "alert-color-dark": "#ff4c4c",
+      "warn-color-dark": "#ffaa33",
+      "text-color": "#e0e0e0",
+    },
+    maintainers: ["Asraye"],
+  },
+};
+
+// Apply a preset
+export const applyTheme = (name: string) => {
+  const preset = themePresets[name];
+  if (!preset) return;
+
+  // Clear previous
+  Object.keys(customColors()).forEach((key) => setThemeColor(key as ThemeKey, undefined));
+  // Apply preset
+  Object.entries(preset.colors).forEach(([key, value]) => setThemeColor(key as ThemeKey, value));
+  // Persist
+  setStorageString(StorageKeys.CUSTOM_COLORS, JSON.stringify(preset.colors));
+};
+
+updateTheme();
+
+export { theme, currentTheme, customColors };

--- a/src/components/settings/InterfaceSettings.tsx
+++ b/src/components/settings/InterfaceSettings.tsx
@@ -116,7 +116,7 @@ export default function InterfaceSettings() {
   );
 }
 
-
+// TODO: Make this look better on mobile before pushing to live
 export function ThemesBlock() {
   return (
     <SettingsBlock

--- a/src/components/settings/InterfaceSettings.tsx
+++ b/src/components/settings/InterfaceSettings.tsx
@@ -8,7 +8,7 @@ import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "i18next";
 import SettingsBlock from "../ui/settings-block/SettingsBlock";
 import { useWindowProperties } from "@/common/useWindowProperties";
-import { currentTheme, customColors, setThemeColor } from "@/common/themes";
+import { themePresets, applyTheme, currentTheme, customColors, setThemeColor } from "@/common/themes";
 import { ColorPicker } from "../ui/color-picker/ColorPicker";
 import Button from "../ui/Button";
 import env from "@/common/env";
@@ -18,6 +18,76 @@ const Container = styled("div")`
   flex-direction: column;
   gap: 5px;
   padding: 10px;
+`;
+
+const ThemeGrid = styled("div")`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 8px;
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ThemeCard = styled("div")<{ colors: Record<string, string> }>`
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  padding: 12px;
+  background-color: ${({ colors }) => colors["pane-color"] || "#f5f5f5"};
+  color: ${({ colors }) => colors["text-color"] || "#333"};
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 12px rgba(0,0,0,0.15);
+  }
+
+  .theme-name {
+    font-weight: bold;
+    margin-bottom: 4px;
+    text-transform: capitalize;
+    font-size: 14px;
+  }
+
+  .maintainers {
+    font-size: 12px;
+    opacity: 0.7;
+    font-style: italic;
+    margin-bottom: 8px;
+  }
+
+  .color-preview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 8px;
+
+    div {
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      background-color: ${({ colors }) => colors["background-color"] || "#eee"};
+    }
+  }
+
+  @media (max-width: 600px) {
+    padding: 10px;
+
+    .color-preview div {
+      width: 16px;
+      height: 16px;
+    }
+
+    button {
+      font-size: 12px;
+      padding: 4px 6px;
+    }
+  }
 `;
 
 export default function InterfaceSettings() {
@@ -36,12 +106,54 @@ export default function InterfaceSettings() {
         <BreadcrumbItem href="/app" icon="home" title={t("dashboard.title")} />
         <BreadcrumbItem title={t("settings.drawer.interface")} />
       </Breadcrumb>
+      <ThemesBlock />
       <BlurEffect />
       <AdvancedMarkup />
       <CustomizeColors />
       <SettingsBlock icon="code" label="Custom CSS" href="./custom-css" />
       <ErudaBlock />
     </Container>
+  );
+}
+
+
+export function ThemesBlock() {
+  return (
+    <SettingsBlock
+      icon="style"
+      label={t("settings.interface.themes")}
+      description={t("settings.interface.themesDescription")}
+      header
+    >
+      <ThemeGrid>
+        <For each={Object.entries(themePresets)}>
+          {([name, { colors, maintainers }]) => {
+            const displayColors = Object.keys(colors).length === 0 ? currentTheme() : colors;
+
+            return (
+              <ThemeCard colors={displayColors}>
+                <div class="theme-name">{name}</div>
+                <Show when={maintainers.length > 0}>
+                  <div class="maintainers">
+                    {t("settings.interface.maintainers")}: {maintainers.join(", ")}
+                  </div>
+                </Show>
+                <div class="color-preview">
+                  {Object.values(displayColors).map((color) => (
+                    <div style={{ "background-color": color }} />
+                  ))}
+                </div>
+                <Button
+                  label={t("settings.interface.apply")}
+                  size="small"
+                  onClick={() => applyTheme(name)}
+                />
+              </ThemeCard>
+            );
+          }}
+        </For>
+      </ThemeGrid>
+    </SettingsBlock>
   );
 }
 

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -349,12 +349,21 @@
       "downloadAppNotice": "Download the Nerimity desktop app to use this feature without window tab focus."
     },
     "interface": {
+      "title": "Settings - Interface",
+      "customCSS": "Custom CSS",
+      "themes": "Themes",
+      "themesDescription": "Pick a preset theme or reset to default.",
+      "maintainers": "Contributors",
+      "apply": "Apply",
+      "enableEruda": "Enable Eruda",
+      "enableErudaDescription": "Enable Eruda for debugging. Do not share any details with others.",
+      "enableOnce": "Enable Once",
       "blurEffect": "Blur Effect",
-      "blurEffectDescription": "Enables transparent blur effect. Disabled by default on mobile. Can cause performance issues.",
+      "blurEffectDescription": "Toggle blur effect on interface elements. (May Reduce Performance)",
       "disableAdvancedMarkupBar": "Disable Advanced Markup Bar",
-      "disableAdvancedMarkupBarDescription": "Disable advanced markup bar from text channels.",
+      "disableAdvancedMarkupBarDescription": "Prevent the advanced markup bar from appearing.",
       "customizeColors": "Customize Colors",
-      "customizeColorsDescription": "Customize the colors of the interface."
+      "customizeColorsDescription": "Edit colors for the current theme."
     }
   },
   "supportBlock": {

--- a/src/locales/list/uw-uw.json
+++ b/src/locales/list/uw-uw.json
@@ -328,11 +328,20 @@
     },
     "interface": {
       "blurEffect": "bwuwwy effect",
-      "blurEffectDescription": "make shinies... (may wag)",
+      "blurEffectDescription": "make shinies... Enabwing bwur may slow some devices~ >w<",
       "disableAdvancedMarkupBar": "no fancy baw",
       "disableAdvancedMarkupBarDescription": "disabwe da advanced text baw uwu",
       "customizeColors": "c-custy cowows",
-      "customizeColorsDescription": "pick nyew cowows uwu"
+      "customizeColorsDescription": "pick nyew cowows uwu",
+      "title": "S-Ssettingsy Intyface OwO",
+      "customCSS": "Cwustom shiny-stuffz >w<",
+      "themes": "Coowowful thewmesies uwu",
+      "themesDescription": "Pick a pwetty thewme owo ow wemind it to defauwt! *giggles*",
+      "maintainers": "Pwetty pewsons who made dis ✨",
+      "apply": "M-make it happen!! >w<",
+      "enableEruda": "Enabble da sneaky debuggies Ewuda~",
+      "enableErudaDescription": "Fow secret debuggy stuffs! Shhh don't teww fwends >///<",
+      "enableOnce": "One-time magic UwU!!"
     }
   },
   "supportBlock": {


### PR DESCRIPTION
Adds themes & theme presets, also add a few more translation strings into `InterfaceSettings.tsx` (and adds those new strings into en-gb/uwu language)

WIP: The theme block UI looks ass on mobile and I couldn't make it better for the life of me.