### PR TITLE
fix: make replies not blinding

### DIFF
--- a/src/common/themes.ts
+++ b/src/common/themes.ts
@@ -83,7 +83,7 @@ export const themePresets: Record<string, ThemePreset> = {
       "warn-color": "#ff8c00",
       "success-color": "#00ff77",
       "success-color-dark": "#00cc44",
-      "primary-color-dark": "#ffffff",
+      "primary-color-dark": "#2d3746",
       "alert-color-dark": "#ff4c4c",
       "warn-color-dark": "#ffaa33",
       "text-color": "#e0e0e0",


### PR DESCRIPTION
<img width="439" height="64" alt="image" src="https://github.com/user-attachments/assets/791357c6-0249-4feb-876a-688c28b89a8e" />

Stop replies looking like this.. woopsie, didn't realise we used primary dark here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the AMOLED theme with a new dark primary color, resulting in a slightly deeper tone for improved readability and contrast.
  * Only the AMOLED preset is affected; all other themes remain unchanged.
  * No feature behavior changes; visuals in AMOLED mode may look subtly different while maintaining overall design consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->