### PR TITLE
fix: don't render tenor links

### DIFF
--- a/src/components/message-pane/message-item/MessageItem.tsx
+++ b/src/components/message-pane/message-item/MessageItem.tsx
@@ -446,6 +446,12 @@ const MessageItem = (props: MessageItemProps) => {
     );
   };
 
+  const processTenorLinks = (content: string) => {
+    if (!content) return content;
+    const tenorRegex =  /(https?:\/\/tenor\.com\/view\/[^\s]+)/g;
+    return content.replace(tenorRegex, "");
+  };
+
   return (
     <>
       <Show when={isNewDay()}>
@@ -541,7 +547,13 @@ const MessageItem = (props: MessageItemProps) => {
                       userContextMenu={props.userContextMenu}
                     />
                   </Show>
-                  <Content message={props.message} hovered={hovered()} />
+                  <Content
+                    message={{
+                      ...props.message,
+                      content: processTenorLinks(props.message.content || ""),
+                    }}
+                    hovered={hovered()}
+                  />
                   <Show when={translatedContent()}>
                     <div class={styles.translationArea}>
                       <span class={styles.title}>


### PR DESCRIPTION
Prevents rendering the tenor link itself, instead just rendering the gif.
<img width="443" height="455" alt="image" src="https://github.com/user-attachments/assets/11744f7c-703c-4b75-9247-bcd2efd38362" />

*Superkitten easter egg in preview??*