### PR TITLE
fix: ensure channel notices update when switching

### DIFF
--- a/src/common/useChannelNotice.ts
+++ b/src/common/useChannelNotice.ts
@@ -1,4 +1,4 @@
-import { createSignal, onMount } from "solid-js";
+import { createSignal, createEffect } from "solid-js";
 import { RawChannelNotice } from "../chat-api/RawData";
 import { getChannelNotice } from "../chat-api/services/ChannelService";
 import { StorageKeys, getStorageObject, setStorageObject } from "@/common/localStorage";
@@ -12,18 +12,21 @@ export const useNotice = (channelId: () => string) => {
 
   const [notice, setNotice] = createSignal<RawChannelNotice | null>(null);
 
-  onMount(async () => {
-    const cachedNotice = cachedNotices[channelId()];
+  createEffect(async () => {
+    const id = channelId();
+    if (!id) return;
+    const cachedNotice = cachedNotices[id];
     if (cachedNotice !== undefined) {
       setNotice(cachedNotice);
       return;
     }
-    const noticeRes = await getChannelNotice(channelId()).catch(() => { });
+    const noticeRes = await getChannelNotice(id).catch(() => { });
     if (!noticeRes) {
-      setCachedNotices(channelId(), null);
+      setCachedNotices(id, null);
+      setNotice(null);
       return;
     }
-    setCachedNotices(channelId(), noticeRes.notice);
+    setCachedNotices(id, noticeRes.notice);
     setNotice(noticeRes.notice);
   });
 


### PR DESCRIPTION
Fixes an issue where switching channels could show the previous channel's notice.  


As shown:
<img width="1116" height="762" alt="image" src="https://github.com/user-attachments/assets/f895980d-fa04-42c3-a50b-9df6b00ad26e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Channel notices load more reliably and handle failures gracefully, preventing stale or partial data.
- Performance
  - Improved caching reduces redundant requests and speeds up notice loading when switching channels.
- Stability
  - Consistent notice identification prevents mismatched or incorrect notices across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->