### PR TITLE
I18n: add typing strings

### DIFF
--- a/src/components/message-pane/MessagePane.tsx
+++ b/src/components/message-pane/MessagePane.tsx
@@ -925,66 +925,66 @@ function TypingIndicator() {
     });
   });
 
-  return (
-    <Floating
-      class={styles.floatingTypingContainer}
-      style={{
-        visibility: typingUsers().length ? "visible" : "hidden",
-        padding: "0px",
-        "padding-left": "5px",
-        "padding-right": "5px",
-        "z-index": "1",
-      }}
-    >
-      <Text size={paneWidth()! < 500 ? 10 : 12} class={styles.typingText}>
-        <Switch>
-          <Match when={typingUserDisplayNames().length === 1}>
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[0]}
-            </strong>{" "}
-            is typing...
-          </Match>
-          <Match when={typingUserDisplayNames().length === 2}>
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[0]}
-            </strong>{" "}
-            and{" "}
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[1]}
-            </strong>{" "}
-            are typing...
-          </Match>
-          <Match when={typingUserDisplayNames().length === 3}>
-            <strong>{typingUserDisplayNames()[0]}</strong>,{" "}
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[1]}
-            </strong>{" "}
-            and{" "}
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[2]}
-            </strong>{" "}
-            are typing...
-          </Match>
-          <Match when={typingUserDisplayNames().length > 3}>
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[0]}
-            </strong>
-            ,{" "}
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[1]}
-            </strong>
-            ,{" "}
-            <strong class={styles.username}>
-              {typingUserDisplayNames()[2]}
-            </strong>{" "}
-            and <strong>{typingUserDisplayNames().length - 3}</strong> others
-            are typing...
-          </Match>
-        </Switch>
-      </Text>
-    </Floating>
+return (
+  <Floating
+    class={styles.floatingTypingContainer}
+    style={{
+      visibility: typingUsers().length ? "visible" : "hidden",
+      padding: "0px",
+      "padding-left": "5px",
+      "padding-right": "5px",
+      "z-index": "1",
+    }}
+  >
+    <Text size={paneWidth()! < 500 ? 10 : 12} class={styles.typingText}>
+      <Switch>
+        <Match when={typingUserDisplayNames().length === 1}>
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[0]}
+          </strong>{" "}
+          {t("typing.single")}
+        </Match>
+        <Match when={typingUserDisplayNames().length === 2}>
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[0]}
+          </strong>{" "}
+          {t("typing.and")}{" "}
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[1]}
+          </strong>{" "}
+          {t("typing.multiple")}
+        </Match>
+        <Match when={typingUserDisplayNames().length === 3}>
+          <strong>{typingUserDisplayNames()[0]}</strong>,{" "}
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[1]}
+          </strong>{" "}
+          {t("typing.and")}{" "}
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[2]}
+          </strong>{" "}
+          {t("typing.multiple")}
+        </Match>
+        <Match when={typingUserDisplayNames().length > 3}>
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[0]}
+          </strong>
+          ,{" "}
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[1]}
+          </strong>
+          ,{" "}
+          <strong class={styles.username}>
+            {typingUserDisplayNames()[2]}
+          </strong>{" "}
+          {t("typing.andOthers", { count: typingUserDisplayNames().length - 3 })}
+        </Match>
+      </Switch>
+    </Text>
+  </Floating>
   );
 }
+
 function SlowModeIndicator() {
   const params = useParams<{ channelId: string; serverId: string }>();
   const { channels, account, channelProperties, serverMembers } = useStore();

--- a/src/components/message-pane/MessagePane.tsx
+++ b/src/components/message-pane/MessagePane.tsx
@@ -85,6 +85,7 @@ import { deleteServer } from "@/chat-api/services/ServerService";
 import { ServerDeleteConfirmModal } from "../servers/settings/ServerGeneralSettings";
 import { useSelectedSuggestion } from "@/common/useSelectedSuggestion";
 import { Portal } from "solid-js/web";
+import { Trans } from "@mbarzda/solid-i18next";
 
 const [sendButtonRef, setSendButtonRef] = createSignal<HTMLButtonElement>();
 
@@ -925,63 +926,68 @@ function TypingIndicator() {
     });
   });
 
-return (
-  <Floating
-    class={styles.floatingTypingContainer}
-    style={{
-      visibility: typingUsers().length ? "visible" : "hidden",
-      padding: "0px",
-      "padding-left": "5px",
-      "padding-right": "5px",
-      "z-index": "1",
-    }}
-  >
-    <Text size={paneWidth()! < 500 ? 10 : 12} class={styles.typingText}>
-      <Switch>
-        <Match when={typingUserDisplayNames().length === 1}>
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[0]}
-          </strong>{" "}
-          {t("typing.single")}
-        </Match>
-        <Match when={typingUserDisplayNames().length === 2}>
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[0]}
-          </strong>{" "}
-          {t("typing.and")}{" "}
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[1]}
-          </strong>{" "}
-          {t("typing.multiple")}
-        </Match>
-        <Match when={typingUserDisplayNames().length === 3}>
-          <strong>{typingUserDisplayNames()[0]}</strong>,{" "}
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[1]}
-          </strong>{" "}
-          {t("typing.and")}{" "}
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[2]}
-          </strong>{" "}
-          {t("typing.multiple")}
-        </Match>
-        <Match when={typingUserDisplayNames().length > 3}>
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[0]}
-          </strong>
-          ,{" "}
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[1]}
-          </strong>
-          ,{" "}
-          <strong class={styles.username}>
-            {typingUserDisplayNames()[2]}
-          </strong>{" "}
-          {t("typing.andOthers", { count: typingUserDisplayNames().length - 3 })}
-        </Match>
-      </Switch>
-    </Text>
-  </Floating>
+  return (
+    <Floating
+      class={styles.floatingTypingContainer}
+      style={{
+        visibility: typingUsers().length ? "visible" : "hidden",
+
+        padding: "0px",
+        "padding-left": "5px",
+        "padding-right": "5px",
+        "z-index": "1",
+      }}
+    >
+      <Text size={paneWidth()! < 500 ? 10 : 12} class={styles.typingText}>
+        <Switch>
+          <Match when={typingUserDisplayNames().length === 1}>
+            <Trans
+              key="typing.single"
+              options={{ username: typingUserDisplayNames()[0] }}
+            >
+              <strong class={styles.username}>{"username"}</strong> is typing...
+            </Trans>
+          </Match>
+          <Match when={typingUserDisplayNames().length === 2}>
+            <Trans
+              key="typing.multiple"
+              options={{
+                username: typingUserDisplayNames()[0],
+                username2: typingUserDisplayNames()[1],
+              }}
+            >
+              <strong class={styles.username} />a
+              <strong class={styles.username} /> at
+            </Trans>
+          </Match>
+          <Match when={typingUserDisplayNames().length === 3}>
+            <Trans
+              key="typing.tripple"
+              options={{
+                username: typingUserDisplayNames()[0],
+                username2: typingUserDisplayNames()[1],
+                username3: typingUserDisplayNames()[2],
+              }}
+            >
+              <strong class={styles.username} />,
+              <strong class={styles.username} />, a
+              <strong class={styles.username} /> at
+            </Trans>
+          </Match>
+          <Match when={typingUserDisplayNames().length > 3}>
+            <Trans
+              key="typing.andOthers"
+              options={{
+                count: typingUserDisplayNames().length,
+              }}
+            >
+              <strong class={styles.username} />
+              at
+            </Trans>
+          </Match>
+        </Switch>
+      </Text>
+    </Floating>
   );
 }
 

--- a/src/components/message-pane/styles.module.scss
+++ b/src/components/message-pane/styles.module.scss
@@ -60,7 +60,7 @@
   .typingText {
     display: flex;
     line-height: 20px;
-    gap: 4px;
+    white-space: break-spaces;
   }
   .username {
     display: block;
@@ -386,11 +386,11 @@ body .floating.floatingSlowModeIndicator {
   background: transparent;
   resize: none;
   font-size: 12px;
-  
+
   &:placeholder-shown {
     text-overflow: ellipsis;
   }
-  
+
   &::placeholder {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -471,7 +471,6 @@ body .messageArea .floating.floatingAttachment.mobile .attachmentContent {
   }
 }
 
-
 .reminderButton {
   position: relative;
   .reminderDot {
@@ -482,11 +481,8 @@ body .messageArea .floating.floatingAttachment.mobile .attachmentContent {
     height: 8px;
     border-radius: 50%;
     background-color: var(--alert-color);
-
   }
 }
-
-
 
 .scheduledDeleteContainer {
   display: flex;
@@ -507,8 +503,6 @@ body .messageArea .floating.floatingAttachment.mobile .attachmentContent {
     font-size: 16px;
   }
 }
-
-
 
 .dropOverlayContainer {
   position: absolute;

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -413,6 +413,12 @@
       "mute": "Mute"
     }
   },
+   "typing": {
+    "single": "is typing…",
+    "multiple": "are typing…",
+    "and": "and",
+    "andOthers": "and {{count}} others are typing…"
+  },
   "userContextMenu": {
     "viewProfile": "View Profile",
     "sendMessage": "Send Message",

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -414,10 +414,10 @@
     }
   },
    "typing": {
-    "single": "is typing…",
-    "multiple": "are typing…",
-    "and": "and",
-    "andOthers": "and {{count}} others are typing…"
+    "single": "<1>{{username}}</1> is typing…",
+    "multiple": "<1>{{username}}</1> and <2>{{username2}}</2> are typing…",
+    "tripple": "<1>{{username}}</1>, <2>{{username2}}</2> and <2>{{username3}}</2> are typing…",
+    "andOthers": "<1>{{count}}</1> users are typing…"
   },
   "userContextMenu": {
     "viewProfile": "View Profile",

--- a/src/locales/list/uw-uw.json
+++ b/src/locales/list/uw-uw.json
@@ -260,7 +260,27 @@
       "deleteAccountDescription": "c-can't undo dis!!",
       "deleteAccountNotice": "must weave/dwop sewvews befowe dewete uwu",
       "understoodButton": "got it!",
-      "save": "saving... nya~"
+      "save": "saving... nya~",
+      "botID": "senpai id",
+      "confirmEmail": "Confywm youw emayw~",
+      "enterCode": "Entew the 5-digit codey sent to youw emayw~!",
+      "sendCodeButton": "SEND IT!!",
+      "resendIn": "Wesend in {{time}}",
+      "confirmButton": "Yee",
+      "cancelButton": "NO",
+      "channelNoticeTooLong": "Channyw nyotice can't be wongew than 300 chawactews!!",
+      "deletionNotice": "NOOO~!! Don't weave us wike dis!! If sumfin bugged you, pwetty pwease teww us in the officiaw Newimity sewvie... we can change",
+      "deletedInfo": {
+        "title": "What will poof",
+        "email": "• Youw emayww~",
+        "username": "• Usewname",
+        "ip": "• IP Addwess",
+        "bio": "• Youw bio",
+        "messages": "• Aww youw messageys",
+        "posts": "• Youw postsies"
+      },
+      "postsAndMessagesNotice": "Youw posts and messageys might take a few weeks to aww poof",
+      "deleteCheckbox": "Get rid of aww my posts and msgs, pwease!!"
     },
     "privacy": {
       "lastOnline": {
@@ -391,6 +411,12 @@
     "reply": "wepwy",
     "markUnread": "mawk unwead"
   },
+   "typing": {
+    "single": "is mashing their keyboawd",
+    "multiple": "awwe typing… nya~",
+    "and": "an'",
+    "andOthers": "an' {{count}} othews"
+  },
   "profile": {
     "followButton": "fowwow uwu",
     "unfollowButton": "unfowwow :c",
@@ -433,7 +459,8 @@
     "resetting": "wesetting...",
     "email": "emaiw",
     "sendEmailButton": "send emaiw",
-    "sending": "sending emaiw..."
+    "sending": "sending emaiw...",
+    "passwordTooLong": "Passwowd must be wess than 72 chawactews~! >w<"
   },
   "dashboard": {
     "title": "dashyboawd",
@@ -464,12 +491,12 @@
     "notifications": "nya-tifurrcations",
     "settings": "settin's",
     "copyId": "copy magic id",
-    "leave": "weave",
     "notificationOptions": {
       "everything": "evewything",
       "mentionsOnly": "mentions onwy",
       "mute": "shh~ mute"
-    }
+    },
+    "leave": "weave"
   },
   "informationDrawer": {
     "title": "info nya~",

--- a/src/locales/list/uw-uw.json
+++ b/src/locales/list/uw-uw.json
@@ -412,10 +412,10 @@
     "markUnread": "mawk unwead"
   },
    "typing": {
-    "single": "is mashing their keyboawd",
-    "multiple": "awwe typing… nya~",
-    "and": "an'",
-    "andOthers": "an' {{count}} othews"
+    "single": "<1>{{username}}</1> is mashing their keyboawd",
+    "multiple": "<1>{{username}}</1> an' <2>{{username2}}</2> awwe typing… nya~",
+    "tripple": "<1>{{username}}</1>, <2>{{username2}}</2> an' <2>{{username3}}</2> awwe typing… nya~",
+    "andOthers": "<1>{{count}}</1> uwsers awe typing..."
   },
   "profile": {
     "followButton": "fowwow uwu",


### PR DESCRIPTION
Adds typing strings to MessagePane, and updates en-gb & uwu language to include them :P

Also completes my previous PR https://github.com/Nerimity/nerimity-web/pull/183 (which I've now closed in favour of this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Typing indicator now localized, showing context-aware phrases for single and multiple users typing.
  * Added comprehensive localization for account deletion flow, including verification steps, notices, and post-deletion details.
  * Introduced “Leave” option in server context menu and dashboard notification options.
  * Added password length validation message during password reset.
* Localization
  * Expanded en-GB and additional locale with new “typing” translations (single, multiple, conjunctions).
  * Broadened account, profile, and navigation strings to improve internationalized user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->