### PR TITLE
i18n: Message area

### DIFF
--- a/src/components/message-pane/MessagePane.tsx
+++ b/src/components/message-pane/MessagePane.tsx
@@ -1515,7 +1515,7 @@ function BackToBottomButton(props: { scrollElement: HTMLDivElement }) {
       <div class={styles.backToBottom} onClick={onClick}>
         <Show when={newMessages()}>
           <Text class={styles.text} size={14}>
-            New messages
+            {t("messageView.newMessages")}
           </Text>
         </Show>
         <Icon

--- a/src/components/message-pane/message-log-area/MessageLogArea.tsx
+++ b/src/components/message-pane/message-log-area/MessageLogArea.tsx
@@ -644,9 +644,9 @@ export const MessageLogArea = (props: {
         <div class={styles.noMessages}>
           <Icon name="comment" size={40} color="var(--primary-color)" />
           <div>
-            <div class={styles.noMessagesTitle}>No messages</div>
+            <div class={styles.noMessagesTitle}>{t("messageView.noMessages")}</div>
             <div class={styles.noMessagesText}>
-              There are no messages in this channel.
+              {t("messageView.noMessagesDescription")}
             </div>
           </div>
         </div>
@@ -801,7 +801,7 @@ function UnreadMarker(props: { onClick: () => void }) {
     <div onClick={props.onClick} class={styles.unreadMarkerContainer}>
       <div class={styles.unreadMarker}>
         <Icon name="mark_chat_unread" size={14} />
-        New Messages
+        {t("messageView.newMessages")}
         <Button
           iconSize={14}
           class={styles.closeButton}

--- a/src/locales/list/be-xo.json
+++ b/src/locales/list/be-xo.json
@@ -601,6 +601,11 @@
       "mute": "Заглушаныя"
     }
   },
+  "messageView": {
+    "noMessages": "Няма паведамленьняў",
+    "noMessagesDescription": "У гэтым канале адсутнічаюць паведамленьні.",
+    "newMessages": "Новыя паведамленьні"
+  },
   "typing": {
     "single": "<1>{{username}}</1> піша…",
     "multiple": "<1>{{username}}</1> і <2>{{username2}}</2> пішуць…",

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -616,6 +616,11 @@
       "mute": "Mute"
     }
   },
+  "messageView": {
+    "noMessages": "No messages",
+    "noMessagesDescription": "There are no messages in this channel.",
+    "newMessages": "New messages"
+  },
   "typing": {
     "single": "<1>{{username}}</1> is typing…",
     "multiple": "<1>{{username}}</1> and <2>{{username2}}</2> are typing…",


### PR DESCRIPTION
## What does this PR do?
Adds strings for message area

## Screenshots
<img width="251" height="167" alt="image" src="https://github.com/user-attachments/assets/090a95a7-ece3-4f54-822a-7ba70483ea30" />
<img width="455" height="256" alt="image" src="https://github.com/user-attachments/assets/836e98f2-c660-4259-bf18-abf084ad1582" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization support for message view UI text, including empty state messages, descriptive messaging, and new message notifications across supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->