### PR TITLE
Deprecate "submitToGithub" (Explore - Themes)

### DIFF
--- a/src/components/explore/ExploreThemes.tsx
+++ b/src/components/explore/ExploreThemes.tsx
@@ -169,7 +169,7 @@ export default function ExploreThemes() {
           `}
         />
         <GitHubButton
-          label={t("explore.themes.submitToGitHub")}
+          label="GitHub"
           iconName="code"
           margin={[0, 0, 0, 4]}
           onClick={() =>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -135,7 +135,6 @@
     "themes": {
       "title": "Explore - Themes",
       "themesHeaderDescription": "Personalize Nerimity with a custom theme.",
-      "submitToGitHub": "GitHub",
       "officialThemes": "Official Themes",
       "communityThemes": "Community Themes",
       "noCommunityThemes": "No community themes found.",


### PR DESCRIPTION
## What does this PR do?
Removed i18n string for GitHub

## Did you test your code?
Yes

## Additional context
That will probably be the last tiny PR for now, I'm going to focus on hard-coded strings once again.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] Text/content changes support internationalization (i18n)  
- [ ] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub button labeling in the Explore Themes section to use hardcoded text instead of localized strings across different language variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->