### PR TITLE
i18n: Translate Mobile Bottom Pane

### DIFF
--- a/src/components/ui/MobileBottomPane.tsx
+++ b/src/components/ui/MobileBottomPane.tsx
@@ -16,6 +16,7 @@ import { userStatusDetail } from "@/common/userStatus";
 import { ConnectionErrorModal } from "../connection-error-modal/ConnectionErrorModal";
 import { useCustomPortal } from "./custom-portal/CustomPortal";
 import { useReminders } from "../useReminders";
+import { t } from "@nerimity/i18lite";
 
 export default function MobileBottomPane() {
   const drawer = useDrawer();
@@ -69,7 +70,7 @@ function HomeItem() {
   return (
     <AnchorItem
       selected={isSelected()}
-      title="Home"
+      title={t("sidePane.homeShort")}
       icon="home"
       href="/app"
       notify={count() ? { count: count(), top: 3, right: 16 } : undefined}
@@ -80,7 +81,7 @@ function SettingsItem() {
   const { tickets } = useStore();
   return (
     <AnchorItem
-      title="Settings"
+      title={t("settings.drawer.title")}
       icon="settings"
       href="/app/settings/account"
       notify={
@@ -99,7 +100,7 @@ function ModerationItem() {
   return (
     <Show when={hasModeratorPerm()}>
       <AnchorItem
-        title="Mod"
+        title={t("sidePane.moderationShort")}
         icon="security"
         href="/app/moderation/"
         selected={!!selected()}
@@ -228,7 +229,7 @@ function UserItem() {
           <Icon name="error" class={style.errorIcon} size={24} />
         </Show>
       </div>
-      Me
+      {t("settings.drawer.profile")}
     </ItemContainer>
   );
 }

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -125,7 +125,9 @@
   },
   "sidePane": {
     "home": "Home",
+    "homeShort": "Home",
     "moderation": "Moderation Pane",
+    "moderationShort": "Mod",
     "addServer": "Add Server"
   },
   "updateModal": {


### PR DESCRIPTION
## What does this PR do?
Adds new strings for Mobile Bottom Pane

## Screenshots
None yet

## Did you test your code?
Yes

## Additional context
`*.homeShort` is exclusively for mobile view since some languages might have a long translation for "Home" in sidebar on wide screens. @Chirunos can you please mention this in string context?

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Implemented internationalization framework for mobile bottom navigation and settings interface labels, including Home, Settings, Moderation, and Profile. Added abbreviated text variants to optimize interface spacing. These changes enable full multi-language support, enhancing global accessibility and preparing the application for seamless localization across diverse user language preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->