### PR TITLE
i18n: Update Information header

### DIFF
--- a/src/components/right-drawer/RightDrawer.tsx
+++ b/src/components/right-drawer/RightDrawer.tsx
@@ -199,7 +199,7 @@ const Header = (props: {
           props.selectedPage === "info" && selectedHeaderButtonStyle
         )}
         iconName="info"
-        label="Info"
+        label={t("informationDrawer.info")}
         type="hover_border"
         onClick={() => props.onChange("info")}
         margin={0}
@@ -211,7 +211,7 @@ const Header = (props: {
         )}
         iconName="attach_file"
         type="hover_border"
-        label="Files"
+        label={t("informationDrawer.files")}
         onClick={() => props.onChange("attachments")}
         margin={0}
         iconSize={16}
@@ -221,7 +221,7 @@ const Header = (props: {
           props.selectedPage === "search" && selectedHeaderButtonStyle
         )}
         iconName="search"
-        label="Search"
+        label={t("explore.search")}
         type="hover_border"
         onClick={() => props.onChange("search")}
         margin={0}
@@ -661,7 +661,20 @@ const SearchDrawer = () => {
   return (
     <div class={styles.searchDrawer} ref={setContainerEl}>
       <Input
-        placeholder={`Search ${!isDMChannel() ? "in " : ""}${name() || ""}`}
+        // placeholder={`Search ${!isDMChannel() ? "in " : ""}${name() || ""}`}
+        placeholder={
+          channel()?.name
+            ? t("informationDrawer.searchBarChannelPlaceholder", {
+                channelName: channel()!.name,
+                interpolation: { escapeValue: false },
+              })
+            : channel()?.recipient()?.username
+            ? t("informationDrawer.searchBarPlaceholder", {
+                username: channel()?.recipient()?.username,
+                interpolation: { escapeValue: false },
+              })
+            : ""
+        }
         onText={setQuery}
         value={query()}
       />

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -837,7 +837,10 @@
     "optionNumberPlaceholder": "Option {{number}}"
   },
   "informationDrawer": {
-    "title": "Information",
+    "info": "Info",
+    "files": "Files",
+    "searchBarPlaceholder": "Search {{username}}",
+    "searchBarChannelPlaceholder": "Search in {{channelName}}",
     "channelNotice": "Channel Notice",
     "attachments": "Attachments",
     "attachmentsBack": "Back",


### PR DESCRIPTION
## What does this PR do?
Adds strings for the updated information drawer header

## Screenshots
<img width="311" height="104" alt="image" src="https://github.com/user-attachments/assets/cea38ed6-349c-454f-8862-355f8fde925f" />

## Did you test your code?
Yes

## Additional context
Changed the "Information" title string to "*.info" because the first is no longer used

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated header labels (Info, Files, Search) for enhanced clarity in the information drawer.
  * Search input placeholders now dynamically display contextual information (channel name or recipient username) for improved user guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->