### PR TITLE
Translate Profile

### DIFF
--- a/src/components/profile-pane/ProfilePane.tsx
+++ b/src/components/profile-pane/ProfilePane.tsx
@@ -510,7 +510,7 @@ const ActionButtons = (props: {
         <CustomLink href={"/app/moderation/users/" + params.userId}>
           <ActionButton
             icon="security"
-            label={t("profile.adminPanelButton")}
+            label="Admin Panel"
             color={props.primaryColor || "var(--primary-color)"}
           />
         </CustomLink>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -821,7 +821,6 @@
     "blockButton": "Block",
     "unblockButton": "Unblock",
     "reportButton": "Report",
-    "adminPanelButton": "Admin Panel",
     "copyLinkButton": "Copy Profile URL",
     "mutualFriends": "Mutual Friends ({{count}})",
     "mutualServers": "Mutual Servers ({{count}})",


### PR DESCRIPTION
## What does this PR do?
Adds translations for Profile Pane

## Screenshots
<img width="1093" height="575" alt="Здымак экрана ад 2025-12-24 23-05-45" src="https://g
ithub.com/user-attachments/assets/a5ae60be-93e8-4c7b-91a8-d9e5c7ca6c42" />
<img width="282" height="130" alt="Здымак экрана ад 2025-12-24 22-47-19" src="https://github.com/user-attachments/assets/860cafcb-139a-4b00-ace7-2a62a0c06687" />

## Did you test your code?
Yes

## Additional context
1. I had to refactor the expiration part a little so that it translates correctly in case of a permanent ban.
<img width="728" height="99" alt="Здымак экрана ад 2025-12-24 22-45-02" src="https://github.com/user-attachments/assets/89f5c1ab-86fc-4d12-8cb4-0ed98bde6441" />

2. I plan on editing the remove friend modal, I think I left a comment under it, but just saying it now in case I haven't.

3. The body of removeFriendModal was modified to not include the username since it's already shown in a bow underneath.

4. The notices of following and follower tabs if they're hidden were unified.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internationalization**
  * Replaced hardcoded profile UI text with localized strings across profile panes, context menus, sidebars, badges, and modals.
  * Added new translation keys for profile actions (block/unblock/report/copy), tabs, badge titles, suspension/blocked notices, and the Unfriend modal.
  * UI text and dynamic labels now display consistent, translated content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->