### PR TITLE
Remove duplicated login/logout strings

### DIFF
--- a/src/components/connection-error-modal/ConnectionErrorModal.tsx
+++ b/src/components/connection-error-modal/ConnectionErrorModal.tsx
@@ -41,12 +41,12 @@ export const ConnectionErrorModal = (props: {
       <Show when={hasToken()}>
         <Button
           onClick={logoutClick}
-          label={t("connectionErrorModal.logout")}
+          label={t("header.logoutButton")}
           color="var(--alert-color)"
         />
       </Show>
       <Show when={!hasToken()}>
-        <Button onClick={() => loginPage()} label={t("connectionErrorModal.login")} />
+        <Button onClick={() => loginPage()} label={t("header.loginButton")} />
       </Show>
     </FlexRow>
   );

--- a/src/components/settings/SettingsDrawer.tsx
+++ b/src/components/settings/SettingsDrawer.tsx
@@ -104,7 +104,7 @@ function Footer() {
       <FooterItem
         color="var(--alert-color)"
         icon="logout"
-        label={t("settings.drawer.logout")}
+        label={t("header.logoutButton")}
         onClick={onLogoutClick}
       />
       <InVoiceActions />

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -35,8 +35,6 @@
   "connectionErrorModal": {
     "title": "Connection Error",
     "ok": "OK",
-    "logout": "Logout",
-    "login": "Login",
     "noToken": "No token provided.",
     "suspended": "You are suspended.",
     "reason": "Reason",
@@ -451,7 +449,6 @@
       "interface": "Interface",
       "language": "Language",
       "notifications": "Notifications",
-      "logout": "Logout",
       "developer": "Developer",
       "applications": "Applications",
       "experiments": "Experiments",


### PR DESCRIPTION
## What does this PR do?
Removes unnecessary login/logout strings

## Did you test your code?
Yes

## Additional context
Dropped languages won't display those strings in English, since everything uses header ones

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated logout and login button labels to use shared header translations instead of component-specific translation keys across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->