### PR TITLE
Add general purpose strings to en-gb.json

### DIFF
--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -7,7 +7,7 @@
     "cancelButton": "Cancel",
     "deleteButton": "Delete",
     "confirmButton": "Confirm",
-    "doneButon": "Done",
+    "doneButton": "Done",
     "saveButton": "Save",
     "saveChangesButton": "Save Changes",
     "saving": "Saving…",


### PR DESCRIPTION
## What does this PR do?
Adds most widely used strings to the English locale file

## Screenshots
<img width="607" height="486" alt="Здымак экрана ад 2025-12-31 16-57-05" src="https://github.com/user-attachments/assets/75031f37-aee7-43d4-b1bf-954032be5690" />

## Did you test your code?
Not used anywhere as of right now, doesn't require testing

## Additional context
This is the first step in preparation for reducing project string count and resolving duplicated strings. Next PRs will make use of those so we don't end up with 6 `"backButton": "Back"` strings scattered through the whole file.

Also, "Nothing Selected" and "Select Item" don't seem to fall into any specific category, so added them in here as well.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Text/content changes support internationalization (i18n) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new "general" English (GB) locale group with common UI strings.
  * Included account fields (email, username, password), profile customization labels (avatar, banner, supported file types, browse), and expanded action/control labels (nothing selected, select item, search placeholder, back, cancel, delete, confirm, done, save, save changes, saving, copy link, copy ID).
  * No changes to header strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->