### PR TITLE
i18n: Fully translate Explore

### DIFF
--- a/src/components/explore/ExploreBots.tsx
+++ b/src/components/explore/ExploreBots.tsx
@@ -113,9 +113,9 @@ export default function ExploreBots() {
   ];
 
   const filterOpts: DropDownItem[] = [
-    { id: "all", label: "All" },
-    { id: "online_bots", label: "Online" },
-    { id: "offline_bots", label: "Offline" },
+    { id: "all", label: t("explore.servers.filterAll") },
+    { id: "online_bots", label: t("status.online") },
+    { id: "offline_bots", label: t("status.offline") },
   ];
 
   const update = (newPublicServer: RawExploreItem, index: number) => {
@@ -135,7 +135,7 @@ export default function ExploreBots() {
         <Button
           margin={0}
           href="/app"
-          label={t("explore.backButton")}
+          label={t("general.backButton")}
           iconName="arrow_back"
         />
       </div>
@@ -149,7 +149,7 @@ export default function ExploreBots() {
         `}
       >
         <Input
-          label={t("explore.search")}
+          label={t("general.searchPlaceholder")}
           value={query().search}
           onText={(text) => setQuery({ ...query(), search: text })}
           class={css`
@@ -169,7 +169,7 @@ export default function ExploreBots() {
           }
         />
         <DropDown
-          title="Filter"
+          title={t("explore.filter")}
           items={filterOpts}
           selectedId={query().filter}
           onChange={(i) =>

--- a/src/components/explore/ExploreServers.tsx
+++ b/src/components/explore/ExploreServers.tsx
@@ -153,7 +153,7 @@ export default function ExploreServers() {
           display: flex;
         `}
       >
-        <Button margin={0} href="/app" label={t("explore.backButton")} iconName="arrow_back" />
+        <Button margin={0} href="/app" label={t("general.backButton")} iconName="arrow_back" />
       </div>
       <FlexRow
         gap={10}
@@ -165,7 +165,7 @@ export default function ExploreServers() {
         `}
       >
         <Input
-          label={t("explore.search")}
+          label={t("general.searchPlaceholder")}
           value={query().search}
           onText={(text) => setQuery({ ...query(), search: text })}
           class={css`
@@ -572,6 +572,7 @@ export function ServerBumpModal(props: {
   publicServer: RawExploreItem;
   close(): void;
 }) {
+  const [t] = useTransContext();
   const [verifyToken, setVerifyKey] = createSignal<string | undefined>(
     undefined
   );
@@ -596,7 +597,7 @@ export function ServerBumpModal(props: {
         iconName="close"
         onClick={props.close}
         color="var(--alert-color)"
-        label="Back"
+        label={t("general.backButton")}
       />
       <Show when={verifyToken()}>
         <Button iconName="arrow_upward" label="Bump" onClick={bumpServer} />

--- a/src/components/explore/ExploreThemes.tsx
+++ b/src/components/explore/ExploreThemes.tsx
@@ -150,7 +150,7 @@ export default function ExploreThemes() {
   return (
     <Container>
       <FlexRow style={{ "margin-bottom": "10px" }}>
-        <Button margin={0} href="/app" label="Back" iconName="arrow_back" />
+        <Button margin={0} href="/app" label={t("general.backButton")} iconName="arrow_back" />
       </FlexRow>
 
       <Notice type="info">{t("explore.themes.themesHeaderDescription")}</Notice>
@@ -160,7 +160,7 @@ export default function ExploreThemes() {
         wrap
       >
         <Input
-          label={t("explore.search")}
+          label={t("general.searchPlaceholder")}
           onText={setSearch}
           value={search()}
           class={css`

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -265,10 +265,8 @@
       "joinServerButton": "Join",
       "bumpButton": "Bump ({{count}})"
     },
-    "search": "Search",
     "sort": "Sort",
     "filter": "Filter",
-    "backButton": "Back",
     "by": "By",
     "bumped": "Bumped"
   },


### PR DESCRIPTION
## What does this PR do?
- Deletes duplicated strings related to Explore
- Finishes translations
- Replaces some strings with general.* ones

## Screenshots
<!-- Include screenshots or GIFs to illustrate your changes, if applicable. -->
<img width="1563" height="325" alt="image" src="https://github.com/user-attachments/assets/84247eb3-5c62-4414-85f9-01f037c385f8" />
<img width="1563" height="325" alt="image" src="https://github.com/user-attachments/assets/9e7fc5e6-2f84-4120-9e83-7b4c2b62d459" />
<img width="1563" height="325" alt="image" src="https://github.com/user-attachments/assets/21633489-c120-4aef-948b-40f8dc4f952c" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized translation keys across explore features to use shared, generic localization strings instead of component-specific ones, improving consistency and reducing duplicate translations throughout the explore section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->