### PR TITLE
Fix Explore Themes gap and padding

### DIFF
--- a/src/components/explore/ExploreThemes.tsx
+++ b/src/components/explore/ExploreThemes.tsx
@@ -12,8 +12,8 @@ import { Notice } from "../ui/Notice/Notice";
 const Container = styled("div")`
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 16px;
+  gap: 5px;
+  padding: 10px;
 `;
 
 const GridLayout = styled("div")`


### PR DESCRIPTION
## What does this PR do?
- Adjusts the gap and padding of Themes to match Servers' and Bots'

## Screenshots
![Kooha-2025-12-31-21-28-46](https://github.com/user-attachments/assets/7a117466-9f05-48e3-8724-dd6d8a48f0d1)

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the Explore Themes area for a more compact layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->