### PR TITLE
Update links to profiles in Language Settings

### DIFF
--- a/src/locales/languages.ts
+++ b/src/locales/languages.ts
@@ -14,7 +14,7 @@ export const languages: Record<string, Language> = {
     emoji: "🇬🇧",
     contributors: [
       "https://github.com/SupertigerDev",
-      "https://github.com/Asraye",
+      "Asraye",
       "https://github.com/1enify"
     ],
   },
@@ -35,12 +35,12 @@ export const languages: Record<string, Language> = {
     name: "Arabic",
     nativeName: "العربية",
     emoji: "🇵🇸",
-    contributors: ["https://github.com/TrueLuna"],
+    contributors: ["TrueLuna"],
     rtl: true, // not really used since I manually implemented it in the code. But might be useful in the future.
   },
   "be-tarask": {
     name: "Belarusian (Traditional)",
-    nativeName: "Беларуская (традыцыйная)",
+    nativeName: "Беларуская (тарашкевіца)",
     emoji: "🇧🇾",
     contributors: ["https://github.com/Dzi-Mieha", "https://github.com/1enify"],
   },
@@ -112,7 +112,7 @@ export const languages: Record<string, Language> = {
     nativeName: "Русский",
     emoji: "🇷🇺",
     contributors: [
-      "https://github.com/FAYSi223",
+      "FAYSi223",
       "https://github.com/eshkq",
       "https://github.com/Effently",
     ],
@@ -127,7 +127,7 @@ export const languages: Record<string, Language> = {
     name: "Thai",
     nativeName: "ไทย",
     emoji: "🇹🇭",
-    contributors: ["ccsleep"],
+    contributors: ["https://github.com/CCSleep"],
   },
   "tr-tr": {
     name: "Turkish",
@@ -144,8 +144,8 @@ export const languages: Record<string, Language> = {
     name: "UwU",
     emoji: "🐱",
     contributors: [
-      "https://github.com/spookehneko123",
-      "https://github.com/Asraye",
+      "Berry",
+      "Asraye",
     ],
   },
 };


### PR DESCRIPTION
## What does this PR do?
- Removes links to GitHub profiles that no longer exist from Language Settings

## Screenshots
<img width="479" height="274" alt="Здымак экрана ад 2026-01-04 12-18-11" src="https://github.com/user-attachments/assets/18a1530f-5811-4e43-8f58-a9c492bd4cb6" />
<img width="441" height="400" alt="Здымак экрана ад 2026-01-04 12-18-26" src="https://github.com/user-attachments/assets/bf249edd-9693-43f1-a5f5-c33095397a6b" />

## Did you test your code?
Yes

## Additional context
Also changed the Belarusian native name to a more natural-sounding one

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Belarusian (Traditional) language display name.
  * Simplified contributor attribution format across multiple language entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->