### PR TITLE
i18n: Translate Notifications and External Embed Server Settings

### DIFF
--- a/src/components/servers/settings/ExternalEmbedSettings.tsx
+++ b/src/components/servers/settings/ExternalEmbedSettings.tsx
@@ -88,7 +88,7 @@ export default function ExternalEmbedSettings() {
 
   createEffect(() => {
     header.updateHeader({
-      title: "Settings - External Embed",
+      title: t("settings.drawer.title") + " - " + t("servers.settings.drawer.external-embed"),
       serverId: params.serverId!,
       iconName: "settings",
     });
@@ -130,11 +130,11 @@ export default function ExternalEmbedSettings() {
       <Show when={invites() && !invites()?.length}>
         <Notice
           type="error"
-          title="No Invites Created"
-          description="You must create an invite before you can create an external embed link."
+          title={t("servers.settings.externalEmbed.noInvites.title")}
+          description={t("servers.settings.externalEmbed.noInvites.description")}
           children={
             <Button
-              label="Create Invite"
+              label={t("servers.settings.externalEmbed.noInvites.createButton")}
               styles={{ "margin-left": "auto" }}
               margin={0}
               primary
@@ -151,13 +151,13 @@ export default function ExternalEmbedSettings() {
         <ListContainer>
           <SettingsBlock
             icon="link"
-            label="Create External Embed Link"
-            description="Create an external iframe embed for your website."
+            label={t("servers.settings.externalEmbed.title")}
+            description={t("servers.settings.externalEmbed.description")}
           >
             <FlexRow>
               <Show when={embed() === undefined}>
                 <DropDown
-                  placeholder="Select Invite"
+                  placeholder={t("servers.settings.externalEmbed.dropdownPlaceholder")}
                   onChange={onInviteSelected}
                   items={invites()!.map((invite) => ({
                     id: invite.code,
@@ -168,7 +168,7 @@ export default function ExternalEmbedSettings() {
               <Show when={embed()}>
                 <Button
                   onClick={deleteEmbed}
-                  label="Delete Embed"
+                  label={t("general.deleteButton")}
                   alert
                   primary
                   iconName="delete"
@@ -193,17 +193,17 @@ export default function ExternalEmbedSettings() {
         <FlexRow wrap>
           <FlexColumn gap={8} style={{ flex: 1, "min-width": "300px" }}>
             <Checkbox
-              label="Hide Header"
+              label={t("servers.settings.externalEmbed.options.hideHeader")}
               checked={opts().hide_header}
               onChange={(val) => setOpts({ ...opts(), hide_header: val })}
             />
             <Checkbox
-              label="Hide Members List"
+              label={t("servers.settings.externalEmbed.options.hideMembers")}
               checked={opts().hide_members}
               onChange={(val) => setOpts({ ...opts(), hide_members: val })}
             />
             <Checkbox
-              label="Hide Activity List"
+              label={t("servers.settings.externalEmbed.options.hideActivities")}
               checked={opts().hide_activities}
               onChange={(val) => setOpts({ ...opts(), hide_activities: val })}
             />

--- a/src/components/servers/settings/ServerNotificationSettings.tsx
+++ b/src/components/servers/settings/ServerNotificationSettings.tsx
@@ -3,7 +3,7 @@ import { For, Show, createEffect } from "solid-js";
 import useStore from "@/chat-api/store/useStore";
 import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
 import { css, styled } from "solid-styled-components";
-import { useTransContext } from "@nerimity/solid-i18lite";
+import { t } from "@nerimity/i18lite";
 import Breadcrumb, { BreadcrumbItem } from "@/components/ui/Breadcrumb";
 import RouterEndpoints from "@/common/RouterEndpoints";
 import { RadioBox, RadioBoxItem } from "@/components/ui/RadioBox";
@@ -34,7 +34,6 @@ const RadioBoxContainer = styled("div")`
 `;
 
 export default function ServerNotificationSettings() {
-  const [t] = useTransContext();
   const params = useParams<{ serverId: string; channelId?: string }>();
   const { header, servers, account, channels } = useStore();
   const server = () => servers.get(params.serverId);
@@ -43,7 +42,7 @@ export default function ServerNotificationSettings() {
 
   createEffect(() => {
     header.updateHeader({
-      title: "Settings - Notifications",
+      title: t("settings.drawer.title") + " - " + t("servers.settings.drawer.notifications"),
       serverId: params.serverId!,
       iconName: "settings",
     });
@@ -58,14 +57,14 @@ export default function ServerNotificationSettings() {
 
   const NotificationSoundItems: () => RadioBoxItem[] = () => [
     ...(currentNotificationPingMode() === null
-      ? [{ id: null, label: "Inherit" }]
+      ? [{ id: null, label: t("serverContextMenu.notificationOptions.initial") }]
       : []),
     ...(currentNotificationPingMode() !==
     ServerNotificationPingMode.MENTIONS_ONLY
-      ? [{ id: 0, label: "Everything" }]
+      ? [{ id: 0, label: t("serverContextMenu.notificationOptions.everything") }]
       : []),
-    { id: 1, label: "Mentions Only" },
-    { id: 2, label: "Mute" },
+    { id: 1, label: t("serverContextMenu.notificationOptions.mentionsOnly") },
+    { id: 2, label: t("serverContextMenu.notificationOptions.mute") },
   ];
 
   const onNotificationSoundChange = (item: RadioBoxItem) => {
@@ -77,10 +76,10 @@ export default function ServerNotificationSettings() {
   };
 
   const NotificationPingItems: RadioBoxItem[] = [
-    ...(channel()?.serverId ? [{ id: null, label: "Inherit" }] : []),
-    { id: 0, label: "Everything" },
-    { id: 1, label: "Mentions Only" },
-    { id: 2, label: "Mute" },
+    ...(channel()?.serverId ? [{ id: null, label: t("serverContextMenu.notificationOptions.initial") }] : []),
+    { id: 0, label: t("serverContextMenu.notificationOptions.everything") },
+    { id: 1, label: t("serverContextMenu.notificationOptions.mentionsOnly") },
+    { id: 2, label: t("serverContextMenu.notificationOptions.mute") },
   ];
 
   const onNotificationPingChange = (item: RadioBoxItem) => {
@@ -114,7 +113,7 @@ export default function ServerNotificationSettings() {
 
       <Notice
         type="info"
-        description="These settings will only change for you."
+        description={t("servers.settings.notifications.notice")}
       />
       <SettingsBlock
         class={css`
@@ -122,8 +121,8 @@ export default function ServerNotificationSettings() {
         `}
         header
         icon="priority_high"
-        label="Notification Ping"
-        description="Display a red notification icon."
+        label={t("servers.settings.notifications.ping")}
+        description={t("servers.settings.notifications.pingDescription")}
       >
         <ItemContainer
           alert={
@@ -155,8 +154,8 @@ export default function ServerNotificationSettings() {
           `}
           header
           icon="notifications_active"
-          label="Notification Sound"
-          description="Make a notification sound."
+          label={t("servers.settings.notifications.sound")}
+          description={t("servers.settings.notifications.soundDescription")}
         />
         <RadioBoxContainer>
           <RadioBox
@@ -224,14 +223,14 @@ const ChannelNotificationsBlock = () => {
         `}
         header
         icon="storage"
-        label="Channels"
-        description="Manage notifications per channel."
+        label={t("servers.settings.drawer.channels")}
+        description={t("servers.settings.notifications.channelsDescription")}
       >
         <Show when={overrides().length}>
           <Button
             onClick={resetOverrides}
             iconName="refresh"
-            label={`Reset Overrides (${overrides().length})`}
+            label={t("servers.settings.notifications.resetButton", { count: overrides().length })}
           />
         </Show>
       </SettingsBlock>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -388,6 +388,15 @@
         "deleteChannelButton": "Delete Channel",
         "removeNoticeButton": "Remove Notice"
       },
+      "notifications": {
+        "notice": "These settings will only change for you.",
+        "ping": "Notification Ping",
+        "pingDescription": "Display a notification indicator.",
+        "sound": "Notification Sound",
+        "soundDescription": "Make a sound when receiving a notification.",
+        "channelsDescription": "Manage notifications per channel.",
+        "resetButton": "Reset Overrides({{count}})"
+      },
       "emoji": {
         "title": "Custom Emoji",
         "description": "Add your own emoji.",
@@ -446,6 +455,21 @@
           "emojiSlotsDescription": "200 emoji slots for your server.",
           "hdScreenshare": "1080p@60fps screenshare",
           "hdScreenshareDescription": "Screenshare in 1080p at 60fps."
+        }
+      },
+      "externalEmbed": {
+        "noInvites": {
+          "title": "No Invites Created",
+          "description": "You must create an invite before you can create an external embed link.",
+          "createButton": "Create Invite"
+        },
+        "title": "Create External Embed Link",
+        "description": "Create an external IFrame embed for your website.",
+        "dropdownPlaceholder": "Select Invite",
+        "options": {
+          "hideHeader": "Hide Header",
+          "hideMembers": "Hide Members List",
+          "hideActivities": "Hide Activity List"
         }
       }
     },


### PR DESCRIPTION
## What does this PR do?
- Translates Notifications and External Embed settings for servers

## Screenshots
<img width="897" height="625" alt="image" src="https://github.com/user-attachments/assets/762cbd84-0e18-4be4-b963-e5afe08b62b7" />
<img width="897" height="678" alt="Здымак экрана ад 2026-01-07 22-32-35" src="https://github.com/user-attachments/assets/c4c725a4-7ee2-479c-abc0-24c70c19abfb" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Expanded translation support across server notification settings, including notification preferences, sound options, and reset functionality.
  * Enhanced external embed configuration interface with full localization coverage for all options and labels.
  * Improved multi-language support across settings interfaces for better accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->