### PR TITLE
i18n: In-app Notifications

### DIFF
--- a/src/components/in-app-notification-previews/InAppNotificationPreviews.tsx
+++ b/src/components/in-app-notification-previews/InAppNotificationPreviews.tsx
@@ -210,8 +210,8 @@ export default function InAppNotificationPreviews() {
             <div class={style.actionsContainer}>
               <Show when={notification()?.message}>
                 <Button
-                  label="Mark as Read"
-                  title="Mark as Read"
+                  label={t("serverContextMenu.markAsRead")}
+                  title={t("serverContextMenu.markAsRead")}
                   onClick={markAsRead}
                   padding={3}
                   iconSize={16}
@@ -220,8 +220,8 @@ export default function InAppNotificationPreviews() {
                 />
               </Show>
               <Button
-                label="Dismiss"
-                title="Dismiss"
+                label={t("message.dismissButton")}
+                title={t("message.dismissButton")}
                 onClick={dismissNotification}
                 padding={3}
                 iconSize={16}

--- a/src/components/in-app-notification-previews/useInAppNotificationPreviews.tsx
+++ b/src/components/in-app-notification-previews/useInAppNotificationPreviews.tsx
@@ -12,6 +12,7 @@ import {
   StorageKeys,
 } from "@/common/localStorage";
 import { isMentioned } from "@/common/Sound";
+import { t } from "@nerimity/i18lite";
 import { createStore, reconcile } from "solid-js/store";
 
 interface InAppPreviewNotification {
@@ -58,7 +59,7 @@ const buildMessageNotification = (
     title: `${displayName} ${
       server ? `(#${channel?.name} ${server?.name})` : ""
     }`,
-    body: message.content || "Attachment",
+    body: message.content || t("message.imageMessage"),
     color: mentioned ? "var(--alert-color)" : undefined,
     channel,
     message,

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1045,6 +1045,7 @@
     "reactions": {
       "more": "{{count}} more"
     },
+    "imageMessage": "Image message",
     "deletedMessage": "Message was deleted.",
     "dismissButton": "Dismiss",
     "editedAt": "Edited at {{time}}",


### PR DESCRIPTION
## What does this PR do?
- Translate In-app Notifications

## Screenshots
<img width="532" height="97" alt="image" src="https://github.com/user-attachments/assets/67e59e33-8699-4e0f-aa6e-6f09adb8299f" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Replaced hardcoded UI text in in-app notifications with internationalized labels, including "Mark as Read" and "Dismiss" button text and default notification messages.
  * Added new translation keys to localization resources to enable multi-language support for notification previews and image message notifications, allowing better user experience across different locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->