### PR TITLE
i18n: Purge strings for Image Cropper, Color Picker, and Photo editor

### DIFF
--- a/src/components/ui/ImageCropModal.tsx
+++ b/src/components/ui/ImageCropModal.tsx
@@ -106,7 +106,7 @@ export default function ImageCropModal(props: {
       actionButtons={
         <Button
           iconName="check"
-          label={t("imageCropModal.done")}
+          label={t("general.doneButton")}
           onClick={onClick}
           styles={{ flex: 1 }}
           primary

--- a/src/components/ui/color-picker/ColorPicker.tsx
+++ b/src/components/ui/color-picker/ColorPicker.tsx
@@ -278,7 +278,7 @@ export const ColorPickerModal = (props: {
       </Modal.Body>
       <Modal.Footer>
         <Modal.Button
-          label={t("colorPickerModal.done")}
+          label={t("general.doneButton")}
           onClick={done}
           iconName="check"
           primary

--- a/src/components/ui/photo-editor/PhotoEditor.tsx
+++ b/src/components/ui/photo-editor/PhotoEditor.tsx
@@ -384,11 +384,11 @@ export default function PhotoEditor(props: PhotoEditorProps) {
       actionButtonsArr={[
         {
           iconName: "close",
-          label: t("photoEditor.cancel"),
+          label: t("general.cancelButton"),
           onClick: props.close,
           color: "var(--alert-color)",
         },
-        { iconName: "check", label: t("photoEditor.edit"), onClick: onDone },
+        { iconName: "check", label: t("general.editButton"), onClick: onDone },
       ]}
       ignoreBackgroundClick
     >
@@ -396,7 +396,7 @@ export default function PhotoEditor(props: PhotoEditorProps) {
 
       <div class={styles.buttons}>
         <Button
-          hoverText={t("photoEditor.undo")}
+          hoverText={t("general.undoButton") + " (Ctrl + Z)"}
           onClick={undo}
           iconName="undo"
           margin={0}

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1064,14 +1064,10 @@
     }
   },
   "colorPickerModal": {
-    "title": "Colour Picker",
-    "done": "Done"
+    "title": "Colour Picker"
   },
   "photoEditor": {
     "title": "Photo Editor",
-    "cancel": "Cancel",
-    "edit": "Edit",
-    "undo": "Undo (Ctrl + Z)",
     "brush": "Brush",
     "erase": "Erase",
     "strokeWidth": "Stroke width: {{width}}",
@@ -1080,8 +1076,7 @@
     "desktopZoom": "Scroll to Zoom"
   },
   "imageCropModal": {
-    "title": "Crop Image",
-    "done": "Done"
+    "title": "Crop Image"
   },
   "oauth2": {
     "AuthorizeButton": "Authorise",


### PR DESCRIPTION
## What does this PR do?
- Removes duplicated strings for Image Cropper, Color Picker. Photo Editor

## Screenshots
<img width="514" height="735" alt="Здымак экрана ад 2026-01-10 23-50-16" src="https://github.com/user-attachments/assets/adfd9502-c164-4562-86dc-b5e9fdae3934" />
<img width="332" height="608" alt="Здымак экрана ад 2026-01-10 23-50-49" src="https://github.com/user-attachments/assets/3128273c-8402-4bfe-b27c-753dcdf38d6f" />
<img width="1021" height="677" alt="Здымак экрана ад 2026-01-10 23-52-14" src="https://github.com/user-attachments/assets/d4004d1a-e6ce-40c2-a22f-205c3db2748c" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undo button now displays its keyboard shortcut (Ctrl + Z) for easier reference.

* **Chores**
  * Standardized button labels and localization keys across UI components for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->