### PR TITLE
i18n: Translate posts

### DIFF
--- a/src/components/PostsArea.tsx
+++ b/src/components/PostsArea.tsx
@@ -364,9 +364,7 @@ function NewPostArea(props: {
           class={css`
             margin-top: 6px;
           `}
-          description={
-            "Self-harm content is not allowed, account action will be taken."
-          }
+          description={t("posts.postWarning")}
         />
       </Show>
     </NewPostOuterContainer>
@@ -1050,10 +1048,10 @@ export function PostsArea(props: {
           onChange={(v) => setSort(v.id)}
           selectedId={sort() || "0"}
           items={[
-            { id: "latest", label: "Latest" },
-            { id: "mostLiked7Days", label: "Most Liked (7 days)" },
-            { id: "mostLiked30days", label: "Most Liked (30 days)" },
-            { id: "mostLikedAllTime", label: "Most Liked (All time)" },
+            { id: "latest", label: t("posts.sort.latest") },
+            { id: "mostLiked7Days", label: t("posts.sort.mostLiked7Days") },
+            { id: "mostLiked30days", label: t("posts.sort.mostLiked30Days") },
+            { id: "mostLikedAllTime", label: t("posts.sort.mostLikedAllTime") },
           ]}
         />
       </Show>
@@ -1510,7 +1508,7 @@ export function ViewPostModal(props: { close(): void }) {
   return (
     <LegacyModal
       close={onClose}
-      title="Post"
+      title={t("posts.title")}
       class={css`
         display: flex;
         flex-direction: column;
@@ -1521,7 +1519,7 @@ export function ViewPostModal(props: { close(): void }) {
     >
       <MetaTitle>
         {!post() || post()?.deleted
-          ? "Post"
+          ? t("posts.title")
           : `${post()?.createdBy.username}: ${post()?.content}`}
       </MetaTitle>
       <FlexColumn style={{ overflow: "auto", height: "100%" }}>
@@ -1551,7 +1549,7 @@ export function ViewPostModal(props: { close(): void }) {
                       : "rgba(255,255,255,0.6)"
                   }
                 >
-                  {`Replies (${post()?._count?.comments})`}
+                  {t("posts.sections.replies", { count: `${post()?._count?.comments}` })}
                 </Text>
               </ItemContainer>
               <ItemContainer
@@ -1569,7 +1567,7 @@ export function ViewPostModal(props: { close(): void }) {
                       : "rgba(255,255,255,0.6)"
                   }
                 >
-                  {`Likes (${post()?._count?.likedBy})`}
+                  {t("posts.sections.likes", { count: `${post()?._count?.likedBy}` })}
                 </Text>
               </ItemContainer>
               <ItemContainer
@@ -1587,7 +1585,7 @@ export function ViewPostModal(props: { close(): void }) {
                       : "rgba(255,255,255,0.6)"
                   }
                 >
-                  {`Reposts (${post()?._count?.reposts})`}
+                  {t("posts.sections.reposts", { count: `${post()?._count?.reposts}` })}
                 </Text>
               </ItemContainer>
             </Show>
@@ -1659,7 +1657,7 @@ export function DeletePostModal(props: { post: Post; close: () => void }) {
       close={props.close}
       class={deletePostModalStyles}
     >
-      <Modal.Header title="Delete Post?" icon="delete" alert />
+      <Modal.Header title={t("posts.deletePostModal.title")} icon="delete" alert />
       <Modal.Body class={deletePostBodyContainerStyles}>
         <Text size={14}>{t("posts.deletePostModal.message")}</Text>
         <PostItem
@@ -1670,13 +1668,13 @@ export function DeletePostModal(props: { post: Post; close: () => void }) {
       </Modal.Body>
       <Modal.Footer>
         <Modal.Button
-          label="Don't Delete"
+          label={t("general.cancelButton")}
           onClick={props.close}
           iconName="close"
         />
         <Modal.Button
           primary
-          label="Delete"
+          label={t("general.deleteButton")}
           onClick={onDeleteClick}
           iconName="delete"
           color="var(--alert-color)"
@@ -1715,7 +1713,7 @@ export function EditPostModal(props: { post: Post; close: () => void }) {
       desktopMaxWidth={600}
       desktopMinWidth={400}
     >
-      <Modal.Header title="Edit Post" icon="edit" />
+      <Modal.Header title={t("posts.editPostModalTitle")} icon="edit" />
       <Modal.Body>
         <AdvancedMarkupOptions
           showGifPicker
@@ -1749,13 +1747,13 @@ export function EditPostModal(props: { post: Post; close: () => void }) {
       </Modal.Body>
       <Modal.Footer>
         <Modal.Button
-          label="Don't Edit"
+          label={t("general.cancelButton")}
           onClick={props.close}
           iconName="close"
           alert
         />
         <Modal.Button
-          label="Edit"
+          label={t("general.editButton")}
           onClick={onEditClick}
           primary
           iconName="edit"

--- a/src/components/post-area/PostItem.tsx
+++ b/src/components/post-area/PostItem.tsx
@@ -429,15 +429,15 @@ const Actions = (props: {
               ...(showDeleteAndEdit()
                 ? [
                     {
-                      label: props.pinned ? "Unpin" : "Pin",
+                      label: props.pinned ? t("messageContextMenu.unpinMessage") : t("messageContextMenu.pinMessage"),
                       onClick: togglePin,
                       alert: props.pinned,
                       icon: "keep",
                     },
-                    { label: "Edit", onClick: onEditClicked, icon: "edit" },
+                    { label: t("general.editButton"), onClick: onEditClicked, icon: "edit" },
                     { separator: true },
                     {
-                      label: "Delete",
+                      label: t("general.deleteButton"),
                       onClick: onDeleteClick,
                       alert: true,
                       icon: "delete",
@@ -465,7 +465,7 @@ const Actions = (props: {
               },
               { separator: true },
               {
-                label: "Copy Post",
+                label: t("posts.copyPostButton"),
                 onClick: () => {
                   if (!props.post.content?.trim()) return;
                   navigator.clipboard.writeText(props.post.content);
@@ -492,7 +492,7 @@ const Actions = (props: {
                 ? [
                     { separator: true },
                     {
-                      label: "Report",
+                      label: t("profile.reportButton"),
                       onClick: onReportClick,
                       alert: true,
                       icon: "flag",
@@ -545,7 +545,7 @@ const Actions = (props: {
         label={props.post._count?.reposts.toLocaleString()}
       />
       <Show when={showViews()}>
-        <Tooltip tooltip="Estimated Views">
+        <Tooltip tooltip={t("posts.viewCount")}>
           <Button
             margin={0}
             iconSize={16}
@@ -698,10 +698,7 @@ const PollEmbed = (props: { post: Post; poll: RawPostPoll }) => {
 
       <div class={style.footer}>
         <span class={style.votes}>
-          <Text size={12}>{props.poll._count.votedUsers} </Text>
-          <Text size={12} opacity={0.6}>
-            votes
-          </Text>
+          <Text size={12}>{t("posts.voteCount", { count: props.poll._count.votedUsers})}</Text>
         </span>
 
         <Show when={selectedChoiceId() && !votedChoiceId()}>
@@ -709,7 +706,7 @@ const PollEmbed = (props: { post: Post; poll: RawPostPoll }) => {
             onClick={onVoteClick}
             class={style.voteButton}
             primary
-            label="Vote"
+            label={t("posts.voteButton")}
             iconName="check"
             padding={4}
             margin={0}

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -901,16 +901,33 @@
         }
     },
     "posts": {
-        "deletePostModal": {
-            "message": "Are you sure you would like to delete this post?",
-            "cancelButton": "Cancel",
-            "deleteButton": "Delete"
+        "title": "Post",
+        "viewCount": "Estimated Views",
+        "voteButton": "Vote",
+        "voteCount": "{{count}} vote(s)",
+        "copyPostButton": "Copy Post",
+        "sections": {
+            "replies": "Replies ({{count}})",
+            "likes": "Likes ({{count}})",
+            "reposts": "Reposts ({{count}})"
         },
+        "deletePostModal": {
+            "title": "Delete Post?",
+            "message": "Are you sure you would like to delete this post?"
+        },
+        "editPostModalTitle": "Edit Post",
         "postWasDeleted": "This post was deleted!",
+        "sort": {
+            "latest": "Latest",
+            "mostLiked7Days": "Most Liked (7 days)",
+            "mostLiked30Days": "Most Liked (30 days)",
+            "mostLikedAllTime": "Most Liked (All Time)"
+        },
         "someoneLikedYourPost": "<1>{{username}}</1> liked your post!",
         "someoneRepostedYourPost": "<1>{{username}}</1> reposted your post!",
         "someoneFollowedYou": "<1>{{username}}</1> followed you!",
         "someoneRepliedToPost": "<1>{{username}}</1> replied to your post!",
+        "postWarning": "Self-harm content is not allowed, account action will be taken.",
         "createAPostInputPlaceholder": "Create a post…",
         "replyInputPlaceholder": "Reply…",
         "replyButton": "Reply",


### PR DESCRIPTION
## What does this PR do?
- Almost fully translates everything post-related

## Screenshots
<img width="686" height="217" alt="image" src="https://github.com/user-attachments/assets/41ce3d63-7504-4a5b-a72e-7510901a0252" />
<img width="629" height="633" alt="image" src="https://github.com/user-attachments/assets/10ed07d8-b14c-4d55-a2f2-a0e0561d4680" />

## Did you test your code?
Yes

## Additional context
Left out text above posts like "Replying to" and "Reposted by" since I'm not sure how to properly format them

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized
