### PR TITLE
Redesign Invite settings

### DIFF
--- a/src/components/servers/settings/invites/ServerSettingsInvite.tsx
+++ b/src/components/servers/settings/invites/ServerSettingsInvite.tsx
@@ -50,13 +50,16 @@ export default function ServerSettingsInvite() {
       () => params.serverId,
       () => {
         fetchInvites();
-      }
-    )
+      },
+    ),
   );
 
   createEffect(() => {
     header.updateHeader({
-      title: t("settings.drawer.title") + " - " + t("servers.settings.drawer.invites"),
+      title:
+        t("settings.drawer.title") +
+        " - " +
+        t("servers.settings.drawer.invites"),
       serverId: params.serverId!,
       iconName: "settings",
     });
@@ -77,14 +80,14 @@ export default function ServerSettingsInvite() {
     <div
       class={classNames(
         styles.invitesPane,
-        conditionalClass(mobileSize(), styles.mobile)
+        conditionalClass(mobileSize(), styles.mobile),
       )}
     >
       <Breadcrumb>
         <BreadcrumbItem
           href={RouterEndpoints.SERVER_MESSAGES(
             params.serverId,
-            server()?.defaultChannelId!
+            server()?.defaultChannelId!,
           )}
           icon="home"
           title={server()?.name}
@@ -164,7 +167,9 @@ function CustomInvite(props: { invites: any[]; onUpdate: () => void }) {
             margin-bottom: 10px;
           `}
           type="info"
-          description={t("servers.settings.invites.customInviteVerifiedOnlyNotice")}
+          description={t(
+            "servers.settings.invites.customInviteVerifiedOnlyNotice",
+          )}
         />
       </Show>
 
@@ -193,7 +198,7 @@ function CustomInvite(props: { invites: any[]; onUpdate: () => void }) {
             <Button
               onClick={() => copyToClipboard(fullUrl())}
               iconName="content_copy"
-              style={{ "align-self": "stretch", "height": "auto" }}
+              style={{ "align-self": "stretch", height: "auto" }}
             />
           </Show>
         </FlexRow>
@@ -240,23 +245,31 @@ const InviteItem = (props: { invite: any; onDeleted: () => void }) => {
         <div class={styles.details}>
           <A
             href={RouterEndpoints.EXPLORE_SERVER_INVITE_SHORT(
-              props.invite.code
+              props.invite.code,
             )}
             class={styles.url}
           >
             {url}
           </A>
           <div class={styles.otherDetails}>
-            <Icon name="person" size={14} class={styles.icon} />
-            {props.invite.createdBy.username}
-          </div>
-          <div class={styles.otherDetails}>
-            <Icon name="whatshot" size={14} class={styles.icon} />
-            {t("servers.settings.invites.uses", { count: props.invite.uses })}
-          </div>
-          <div class={styles.otherDetails}>
-            <Icon name="today" size={14} class={styles.icon} />
-            {formatTimestamp(props.invite.createdAt)}
+            <div class={styles.detail}>
+              <Icon name="person" size={14} class={styles.icon} />
+              <span class={styles.username}>
+                {props.invite.createdBy.username}
+              </span>
+            </div>
+            <div class={styles.detail}>
+              <Icon name="whatshot" size={14} class={styles.icon} />
+              <span>
+                {t("servers.settings.invites.uses", {
+                  count: props.invite.uses,
+                })}
+              </span>
+            </div>
+            <div class={styles.detail}>
+              <Icon name="today" size={14} class={styles.icon} />
+              <span>{formatTimestamp(props.invite.createdAt)}</span>
+            </div>
           </div>
         </div>
         <FlexRow class={styles.buttons}>
@@ -264,12 +277,16 @@ const InviteItem = (props: { invite: any; onDeleted: () => void }) => {
             onClick={() => copyToClipboard(url)}
             class={classNames(styles.copyButton, styles.button)}
             label={t("general.copyLink")}
+            iconSize={18}
+            textSize={14}
             iconName="content_copy"
           />
           <Button
             onClick={onDeleteClick}
             class={classNames(styles.deleteButton, styles.button)}
             iconName="delete"
+            iconSize={18}
+            textSize={14}
             color="var(--alert-color)"
           />
         </FlexRow>

--- a/src/components/servers/settings/invites/styles.module.scss
+++ b/src/components/servers/settings/invites/styles.module.scss
@@ -5,75 +5,107 @@
 }
 
 .buttons {
-  margin-left: auto;;
+  margin-left: auto;
 }
 
-.mobile .inviteItem  {
-  .detailsOuter{
-    flex-direction: column;
-    align-items: initial;
+.details {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mobile .inviteItem {
+  .detailsOuter {
     align-content: center;
+    align-items: initial;
+    flex-direction: column;
   }
   .buttons {
-    margin-left: initial;
     align-self: flex-start;
     margin-top: 5px;
+    margin-left: initial;
   }
 }
 
 .inviteItem {
   display: flex;
   align-items: center;
+  padding: 10px;
 
   margin-bottom: 2px;
-  padding: 10px;  
-  background: rgba(255, 255, 255, 0.06);
-  
-  border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
-  
+
+  border-bottom-left-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  gap: 6px;
+
   &:not(:last-child) {
-    border-radius: 0;
     margin-bottom: 1px;
+    border-radius: 0;
   }
   .avatar {
     align-self: start;
     margin-top: 4px;
   }
 
-  
   .detailsOuter {
     display: flex;
-    margin-left: 5px;
+    overflow: hidden;
     width: 100%;
+    margin-left: 5px;
   }
   .otherDetails {
+    display: flex;
+    overflow: hidden;
+    align-items: center;
     margin-top: 3px;
     margin-left: -3px;
-    display: flex;
-    align-items: center;
     color: rgba(255, 255, 255, 0.6);
-    font-size: 14px;
+    font-size: 12px;
+    .detail {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
     .icon {
       margin-right: 3px;
       margin-left: 3px;
     }
   }
-
+  .username {
+    overflow: hidden;
+    max-width: 100px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
   .button {
-    font-size: 14px;
+    align-self: center;
     padding: 4px;
     margin: 0;
-    align-self: center;
+    font-size: 14px;
   }
   .copyButton {
-    margin-left: auto;
     margin-right: 5px;
+    margin-left: auto;
   }
 
   .url {
     word-break: break-word;
   }
+}
 
+@media (max-width: 560px) {
+  .inviteItem .otherDetails {
+    align-items: start;
+    flex-direction: column;
+    gap: 6px;
+    .detail {
+      width: 100%;
+    }
+    .username {
+      max-width: 100%;
+    }
+  }
 }


### PR DESCRIPTION
## What does this PR do?
Changes the looks of server invite settings
- List all link info on new lines
- Remove Delete button label

## Screenshots
<img width="899" height="478" alt="image" src="https://github.com/user-attachments/assets/f461ec2a-a6c7-4c87-8dd3-d323d17fbebb" />

## Did you test your code?
Yes

## Additional context
The motivation behind this was the fact that invites don't always display perfectly on mobile, especially with long usernames and/or on locales where the word "uses" is more than 7 letters long.
![Screenshot_20260120_170724.jpg](https://github.com/user-attachments/assets/1245e3e6-43eb-4dde-9ebc-dc8280bf5bc2)

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Invite item layout reorganized into distinct detail lines (creator, uses, date) for clearer alignment.
  * Improved responsive styling: better wrapping on small screens, adjusted spacing, padding, and border behavior.
  * Username now truncates with ellipsis to prevent overflow.
  * Copy button and action spacing refined; copy button aligns to the right and delete action is icon-only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->