### PR TITLE
i18n: Translate dropdowns

### DIFF
--- a/src/components/ui/drop-down/DropDown.tsx
+++ b/src/components/ui/drop-down/DropDown.tsx
@@ -15,6 +15,7 @@ import styles from "./styles.module.scss";
 import { Portal } from "solid-js/web";
 import { useResizeObserver } from "@/common/useResizeObserver";
 import { useWindowProperties } from "@/common/useWindowProperties";
+import { t } from "@nerimity/i18lite";
 
 export interface DropDownItem {
   id: string;
@@ -110,7 +111,7 @@ function ItemTemplate(props: { item?: DropDownItem; placeholder?: string }) {
       <CircleColor color={props.item?.circleColor} />
       <div class={styles.details}>
         <div class={styles.label}>
-          {props.item?.label || props.placeholder || "Select Item"}
+          {props.item?.label || props.placeholder || t("dropDown.selectItem")}
           {props.item?.suffix}
         </div>
         <Show when={props.item?.description}>

--- a/src/components/ui/multi-select-drop-down/MultiSelectDropDown.tsx
+++ b/src/components/ui/multi-select-drop-down/MultiSelectDropDown.tsx
@@ -5,6 +5,7 @@ import styles from "./styles.module.scss";
 import { Portal } from "solid-js/web";
 import { useResizeObserver } from "@/common/useResizeObserver";
 import { useWindowProperties } from "@/common/useWindowProperties";
+import { t } from "@nerimity/i18lite";
 
 
 export interface MultiSelectDropDownItem {
@@ -80,7 +81,7 @@ function ItemTemplate(props: { items?: MultiSelectDropDownItem[], item?: MultiSe
     <div class={styles.itemTemplate}>
       <div class={styles.details}>
         <div>
-          <Show when={props.items}>{props.items ? `${props.items.length} item(s) selected` :"Select Item(s)"}</Show>
+          <Show when={props.items}>{props.items ? t("dropDown.itemsSelected", { count: props.items.length }) : t("dropDown.selectItemMultiple")}</Show>
           <Show when={props.item}>{props.item?.label}</Show>
         </div>
       </div>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1,7 +1,6 @@
 {
     "general": {
         "nothingSelected": "Nothing Selected",
-        "selectItem": "Select Item",
         "searchPlaceholder": "Search",
         "backButton": "Back",
         "cancelButton": "Cancel",
@@ -190,6 +189,11 @@
         "copy": "Copy",
         "cut": "Cut",
         "paste": "Paste"
+    },
+    "dropDown": {
+        "selectItem": "Select Item",
+        "selectItemMultiple": "Select Item(s)",
+        "itemsSelected": "{{count}} item(s) selected"
     },
     "markup": {
         "bold": "Bold",


### PR DESCRIPTION
## What does this PR do?
- Translate dropdown placeholders

## Screenshots
<img width="209" height="60" alt="image" src="https://github.com/user-attachments/assets/88cf3d34-70cc-40e8-98b9-aef105df7e12" />
<img width="318" height="58" alt="image" src="https://github.com/user-attachments/assets/ec91d95b-050a-4140-924d-df26716dafe0" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization support to dropdown and multi-select menus, enabling interface text to display in the user's configured language.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->