### PR TITLE
i18n: Translate the rest of posts

### DIFF
--- a/src/components/post-area/PostItem.tsx
+++ b/src/components/post-area/PostItem.tsx
@@ -49,6 +49,7 @@ import { fetchTranslation, TranslateRes } from "@/common/GoogleTranslate";
 import { toast } from "../ui/custom-portal/CustomPortal";
 import { CreateTicketModal } from "@/components/CreateTicketModal";
 import { Fonts, getFont } from "@/common/fonts";
+import { Trans } from "@nerimity/solid-i18lite";
 
 const viewsEnabledAt = new Date();
 viewsEnabledAt.setUTCFullYear(2024);
@@ -106,7 +107,7 @@ export function PostItem(props: {
       if (!props.post.content) return;
       fetchTranslation(props.post.content)
         .then(setTranslatedContent)
-        .catch(() => toast("Translation failed"));
+        .catch(() => toast(t("message.translation.error")));
     }
   });
 
@@ -186,7 +187,7 @@ export function PostItem(props: {
         <Text>{t("posts.postWasDeleted")}</Text>
       </Show>
       <Show when={props.post.block}>
-        <Text>This user has blocked you.</Text>
+        <Text>{t("profile.blockedDescription")}</Text>
       </Show>
       <Show when={!props.post.deleted && !props.post.block}>
         <Show when={pinned()}>
@@ -307,7 +308,7 @@ const Content = (props: {
           name="edit"
           class={style.editIconStyles}
           size={14}
-          title={`Edited at ${formatTimestamp(props.post.editedAt)}`}
+          title={t("message.editedAt", { time: formatTimestamp(props.post.editedAt) })}
         />
       </Show>
 
@@ -788,15 +789,22 @@ const ReplyTo = (props: { user: RawUser }) => {
   return (
     <div class={style.replyToContainer}>
       <Text size={14} style={{ "margin-right": "5px" }}>
-        Replying to
+        <Trans
+          key="posts.replying"
+          options={{
+            username: props.user?.username
+          }}
+        >
+          Replying to
+          <CustomLink
+            decoration
+            style={{ "font-size": "14px", "line-height": "1" }}
+            href={RouterEndpoints.PROFILE(props.user?.id!)}
+          >
+            {"username"}
+          </CustomLink>
+        </Trans>
       </Text>
-      <CustomLink
-        decoration
-        style={{ "font-size": "14px", "line-height": "1" }}
-        href={RouterEndpoints.PROFILE(props.user?.id!)}
-      >
-        {props.user?.username}
-      </CustomLink>
     </div>
   );
 };
@@ -805,7 +813,7 @@ const Pinned = () => {
     <div class={style.pinnedContainer}>
       <Icon name="keep" color="var(--primary-color)" size={16} />
       <Text size={14} style={{ "margin-right": "5px" }}>
-        Pinned
+        {t("posts.pinned")}
       </Text>
     </div>
   );
@@ -818,9 +826,9 @@ const Reposted = (props: { post: Post; showRepostsAsSelf: boolean | any }) => {
     <div class={style.pinnedContainer}>
       <Icon name="repeat" color="var(--success-color)" size={16} />
       <Text size={14} style={{ "margin-right": "5px" }}>
-        <Show when={props.showRepostsAsSelf}>Reposted</Show>
+        <Show when={props.showRepostsAsSelf}>{t("posts.reposted")}</Show>
         <Show when={!props.showRepostsAsSelf}>
-          Reposted by{" "}
+          {t("posts.repostedBy")}{" "}
           <For each={repostUsers()}>
             {(user, i) => (
               <>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -964,6 +964,10 @@
     "posts": {
         "title": "Post",
         "viewCount": "Estimated Views",
+        "replying": "Replying to <1>{{username}}</1>",
+        "pinned": "Pinned",
+        "reposted": "Reposted",
+        "repostedBy": "Reposted by",
         "voteButton": "Vote",
         "voteCount": "{{count}} vote(s)",
         "copyPostButton": "Copy Post",
@@ -1138,7 +1142,8 @@
         "blocked": "You have blocked this user. Click to show.",
         "translationError": "Could not translate this message.",
         "translation": {
-            "title": "Translation"
+            "title": "Translation",
+            "error": "Translation failed"
         }
     },
     "colorPickerModal": {


### PR DESCRIPTION
## What does this PR do?
- Translate everything left of PostItem

## Screenshots
<img width="243" height="33" alt="image" src="https://github.com/user-attachments/assets/6a3d8050-bd5b-4f00-a857-f4471ed6bff9" />
<img width="86" height="23" alt="image" src="https://github.com/user-attachments/assets/495dc246-6e14-47b5-90db-67f7e4f21095" />
<img width="201" height="31" alt="image" src="https://github.com/user-attachments/assets/e46b7c18-09e3-41b1-9674-f3b571a3cf19" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization support for improved localization across the application.
  * UI elements including post labels, replies, and status indicators now use the translation system.
  * Enhanced error messages with proper localization for better user experience across different languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->