### PR TITLE
i18n: Translate bot button embed popup

### DIFF
--- a/src/components/message-pane/message-item/ButtonsEmbed.tsx
+++ b/src/components/message-pane/message-item/ButtonsEmbed.tsx
@@ -14,6 +14,7 @@ import DropDown from "@/components/ui/drop-down/DropDown";
 import Text from "@/components/ui/Text";
 import { Notice } from "@/components/ui/Notice/Notice";
 import Input from "@/components/ui/input/Input";
+import { t } from "@nerimity/i18lite";
 
 export function ButtonsEmbed(props: { message: RawMessage }) {
   const buttons = () => props.message.buttons || [];
@@ -159,7 +160,7 @@ const ResponseModal = (props: {
   const title = () =>
     props.payload.title
       ? `${props.payload.title} (${props.message.createdBy.username})`
-      : `Response from ${props.message.createdBy.username}`;
+      : t("botButtonModal.title", { botName: props.message.createdBy.username });
 
   const onCloseClick = async () => {
     if (requestSent()) return;
@@ -183,7 +184,7 @@ const ResponseModal = (props: {
       title={title()}
       icon="robot"
       actionButtonsArr={[
-        { label: props.payload.buttonLabel || "Close", onClick: onCloseClick },
+        { label: props.payload.buttonLabel || t("general.closeButton"), onClick: onCloseClick },
       ]}
     >
       <div class={style.modalContent}>
@@ -191,8 +192,8 @@ const ResponseModal = (props: {
           <Notice
             type="caution"
             description={[
-              `Data is sent to ${props.message.createdBy.username}`,
-              "Never share sensitive information",
+              t("botButtonModal.dataReceiver", { botName: props.message.createdBy.username }),
+              t("botButtonModal.notice"),
             ]}
           />
         </Show>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1146,6 +1146,11 @@
             "error": "Translation failed"
         }
     },
+    "botButtonModal": {
+        "title": "Response from {{botName}}",
+        "dataReceiver": "Data is sent to {{botName}}",
+        "notice": "Never share sensitive information"
+    },
     "colorPickerModal": {
         "title": "Colour Picker"
     },


### PR DESCRIPTION
## What does this PR do?
- Translates ButtomEmbed

## Screenshots
<img width="265" height="92" alt="image" src="https://github.com/user-attachments/assets/0a48b90a-8c80-4e07-b3fe-1c17ece16550" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bot button modal messages now support localization with English (GB) translations available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->