### PR TITLE
i18n: Translate Logout Modal

### DIFF
--- a/src/components/settings/LogoutModal.tsx
+++ b/src/components/settings/LogoutModal.tsx
@@ -2,27 +2,28 @@ import { createSignal } from "solid-js";
 import Checkbox from "../ui/Checkbox";
 import { Modal } from "../ui/modal";
 import { logout } from "@/common/logout";
+import { t } from "@nerimity/i18lite";
 
 export const LogoutModal = (props: { close: () => void }) => {
   const [clearLocalSettings, setClearLocalSettings] = createSignal(true);
   return (
     <Modal.Root close={props.close}>
-      <Modal.Header title="Logout?" icon="logout" alert />
-      <Modal.Body>Are you sure you want to logout?</Modal.Body>
+      <Modal.Header title={t("logoutModal.title")} icon="logout" alert />
+      <Modal.Body>{t("logoutModal.body")}</Modal.Body>
       <Checkbox
-        label="Clear Local Settings"
+        label={t("logoutModal.clearSettings")}
         checked={clearLocalSettings()}
         onChange={setClearLocalSettings}
       />
       <Modal.Footer>
         <Modal.Button
-          label="Don't Logout"
+          label={t("logoutModal.cancelButton")}
           onClick={props.close}
           iconName="close"
         />
         <Modal.Button
           primary
-          label="Logout"
+          label={t("header.logoutButton")}
           iconName="logout"
           alert
           onClick={() => logout(undefined, !clearLocalSettings())}

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -812,6 +812,12 @@
         "watching": "Watching",
         "listening": "Listening to"
     },
+    "logoutModal": {
+        "title": "Logout?",
+        "body": "Are you sure you want to log out?",
+        "clearSettings": "Clear Local Settings",
+        "cancelButton": "Don't Logout"
+    },
     "supportBlock": {
         "support": "Support Me",
         "supportDescription": "Donate to get a supporter badge!"


### PR DESCRIPTION
## What does this PR do?
- Translate Logout Modal

## Screenshots
<img width="285" height="176" alt="image" src="https://github.com/user-attachments/assets/fce6fbf6-5ccc-4c76-bc0a-80f6501bb94f" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled multi-language support for the logout confirmation modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->