### PR TITLE
Add new languages to Google Translate

### DIFF
--- a/src/common/GoogleTranslate.ts
+++ b/src/common/GoogleTranslate.ts
@@ -10,6 +10,7 @@ export interface TranslateRes {
 
 const GOOGLE_LANGUAGE_MAP: Record<string, string> = {
   "en-gb": "en",
+  "en-us": "en",
   "af-za": "af",
   "ar-ps": "ar",
   "be-tarask": "be",
@@ -20,6 +21,7 @@ const GOOGLE_LANGUAGE_MAP: Record<string, string> = {
   "fr-fr": "fr",
   "de-de": "de",
   "hu-hu": "hu",
+  "ja-jp": "ja",
   "fil-ph": "tl",
   "pl-pl": "pl",
   "ro-ro": "ro",
@@ -27,6 +29,8 @@ const GOOGLE_LANGUAGE_MAP: Record<string, string> = {
   "es-es": "es",
   "th-th": "th",
   "tr-tr": "tr",
+  "sv-sv": "sv",
+  "uk": "uk",
   "uw-uw": "en",
 };
 


### PR DESCRIPTION
## What does this PR do?
- Make Translate Message feature support new app languages

## Screenshots
<img width="313" height="157" alt="Здымак экрана ад 2026-02-03 19-10-51" src="https://github.com/user-attachments/assets/5db41383-0ebf-4b17-b22d-b0389c4b6b0e" />
<img width="380" height="157" alt="Здымак экрана ад 2026-02-03 19-11-07" src="https://github.com/user-attachments/assets/6c1585a6-1a02-40a0-b9b1-4013f60dc7bf" />
<img width="402" height="157" alt="Здымак экрана ад 2026-02-03 19-12-42" src="https://github.com/user-attachments/assets/70ffa6bb-bbb9-4b24-b5e3-33bb7d9beba8" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation support for additional language locale variants including English (US), Japanese (JP), Swedish, and Ukrainian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->