### PR TITLE
i18n: Translate color type tabs

### DIFF
--- a/src/components/ui/color-picker/ColorPicker.tsx
+++ b/src/components/ui/color-picker/ColorPicker.tsx
@@ -201,14 +201,14 @@ export const ColorPickerModal = (props: {
                 selected={currentTab() === "solid"}
                 onClick={() => setCurrentTab("solid")}
               >
-                <Item.Label>Solid</Item.Label>
+                <Item.Label>{t("colorPickerModal.solid")}</Item.Label>
               </Item.Root>
               <Item.Root
                 handlePosition="bottom"
                 selected={currentTab() === "gradient"}
                 onClick={() => setCurrentTab("gradient")}
               >
-                <Item.Label>Gradient</Item.Label>
+                <Item.Label>{t("colorPickerModal.gradient")}</Item.Label>
               </Item.Root>
             </div>
           </Show>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1162,7 +1162,9 @@
         "notice": "Never share sensitive information"
     },
     "colorPickerModal": {
-        "title": "Colour Picker"
+        "title": "Colour Picker",
+        "solid": "Solid",
+        "gradient": "Gradient"
     },
     "photoEditor": {
         "title": "Photo Editor",


### PR DESCRIPTION
## What does this PR do?
- Translate "Solid" and "Gradient" titles

## Screenshots
<img width="532" height="773" alt="image" src="https://github.com/user-attachments/assets/988b4a5d-3520-4544-8dc4-28784fbc7925" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced color picker component to support multiple languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->