### PR TITLE
i18n: Translate quotes

### DIFF
--- a/src/components/markup/QuoteMessage.tsx
+++ b/src/components/markup/QuoteMessage.tsx
@@ -16,6 +16,7 @@ import {
   emitScrollToMessage,
 } from "@/common/GlobalEvents";
 import { Embeds } from "../message-pane/message-item/MessageItem";
+import { t } from "@nerimity/i18lite";
 
 export function QuoteMessage(props: {
   message: Message;
@@ -79,7 +80,7 @@ export function QuoteMessage(props: {
 
   const editedAt = () => {
     if (!props.quote.editedAt) return;
-    return "Edited at " + formatTimestamp(props.quote.editedAt);
+    return t("message.editedAt", { time: formatTimestamp(props.quote.editedAt) });
   };
 
   const jumpToLink = () => {
@@ -161,7 +162,7 @@ export function QuoteMessage(props: {
           iconName="visibility"
           padding={4}
           iconSize={14}
-          title="View Messages"
+          title={t("message.viewMessages")}
           onClick={() =>
             emitModerationShowMessages({
               messageId: props.quote.id!,
@@ -198,9 +199,9 @@ export function QuoteMessage(props: {
 }
 
 export function QuoteMessageInvalid() {
-  return <div class="quoteContainer">Deleted Or Invalid Quote.</div>;
+  return <div class="quoteContainer">{t("message.quote.invalid")}</div>;
 }
 
 export function QuoteMessageHidden() {
-  return <span class="hiddenQuote">Nested Quote</span>;
+  return <span class="hiddenQuote">{t("message.quote.nested")}</span>;
 }

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1130,7 +1130,12 @@
         "reactions": {
             "more": "{{count}} more"
         },
+        "viewMessages": "View Messages",
         "imageMessage": "Image message",
+        "quote": {
+            "invalid": "Deleted or invalid quote.",
+            "nested": "Nested quote"
+        },
         "deletedMessage": "Message was deleted.",
         "dismissButton": "Dismiss",
         "editedAt": "Edited at {{time}}",


### PR DESCRIPTION
## What does this PR do?
- Translates QuoteMessage.tsx

## Screenshots
<img width="242" height="159" alt="image" src="https://github.com/user-attachments/assets/fef0fe26-15c8-44bc-8a2d-96f937a1b7cc" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization support for message-related text, enabling localized displays for "View Messages", quote messages, and edited message timestamps across different languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->