### PR TITLE
Use tabular numbers for VC time counter

### DIFF
--- a/src/components/servers/drawer/ServerDrawer.tsx
+++ b/src/components/servers/drawer/ServerDrawer.tsx
@@ -535,7 +535,10 @@ function CallTime(props: { channelId: string }) {
 
   return (
     <Show when={channel()?.callJoinedAt}>
-      <Text size={12} opacity={0.6} style={{ "margin-left": "auto" }}>
+      <Text size={12} opacity={0.6} style={{
+        "margin-left": "auto",
+        "font-variant-numeric": "tabular-nums"
+      }}>
         {time()}
       </Text>
     </Show>


### PR DESCRIPTION
## What does this PR do?

Enables tabular numbers for the voice chat time counter, to prevent the numbers shifting due to character widths (`font-variant-numeric: tabular-nums;`).  This works with the current UI font and should work with most other fonts.

## Screenshots

Before:
https://github.com/user-attachments/assets/bfe71e17-bc6d-45c2-a59c-f2222a357be5

After:
https://github.com/user-attachments/assets/92b2b88b-1b63-4c91-9b14-c9ae3df0887b

## Did you test your code?

Tested by manually applying the same CSS modifications; I haven't been able to get a local instance running yet.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [ ] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved call time display formatting to ensure consistent number rendering with tabular numerals for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->