### PR TITLE
Clamp panel resize width to make resizing smoother

### DIFF
--- a/src/components/ui/ResizeBar.tsx
+++ b/src/components/ui/ResizeBar.tsx
@@ -29,8 +29,8 @@ export const useResizeBar = (opts: ResizeBarOpts) => {
     if (opts.invert) {
       newWidth = startWidth - (event.clientX - startX);
     }
-    if (newWidth < opts.minWidth) return;
-    if (newWidth >= opts.maxWidth) return;
+    if (newWidth < opts.minWidth) newWidth = opts.minWidth;
+    if (newWidth >= opts.maxWidth) newWidth = opts.maxWidth;
     if (opts.element()) {
       setWidth(newWidth);
     }


### PR DESCRIPTION
## What does this PR do?

When the target resize width for a panel is too large/small, clamp it instead of ignoring the drag; otherwise, quick mouse moves can skip the endpoints, making the resize stop following the cursor.

## Screenshots

Before:
https://github.com/user-attachments/assets/57970c73-bc56-4578-a4cf-981f3f08714b

After:
https://github.com/user-attachments/assets/7ec640ba-7dbe-41fc-ba3f-bfa319ba6651

## Did you test your code?

See above videos.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~  (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resize handle behavior to properly constrain width values within minimum and maximum boundaries during drag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->