### PR TITLE
Hide reply/quote options in channels without send permission

### DIFF
--- a/src/chat-api/store/useServerMembers.ts
+++ b/src/chat-api/store/useServerMembers.ts
@@ -26,7 +26,7 @@ export type ServerMember = Omit<RawServerMember, "user"> & {
     bitwise: { bit: number },
     ignoreAdmin?: boolean,
     ignoreCreator?: boolean
-  ) => boolean | void;
+  ) => boolean;
   topRole: () => ServerRole;
   topRoleWithIcon: () => ServerRole | undefined;
   unhiddenRole: () => ServerRole | undefined;

--- a/src/components/message-pane/MessagePane.tsx
+++ b/src/components/message-pane/MessagePane.tsx
@@ -230,22 +230,7 @@ function MessagePane() {
   const muted = () =>
     member()?.muteExpireAt && new Date(member()?.muteExpireAt!) > new Date();
 
-  const canSendMessage = () => {
-    if (isEmailNotConfirmed()) {
-      return false;
-    }
-    if (!channel()?.serverId) return true;
-    if (!member()) return false;
-    if (member()?.hasPermission(ROLE_PERMISSIONS.ADMIN)) return true;
-
-    if (muted()) return false;
-
-    if (!channel()?.hasPermission(CHANNEL_PERMISSIONS.SEND_MESSAGE)) {
-      return false;
-    }
-
-    return member()?.hasPermission(ROLE_PERMISSIONS.SEND_MESSAGE);
-  };
+  const canSendMessage = () => channel()?.canSendMessage(account.user()?.id!);
 
   const server = () => servers.get(channel()?.serverId!);
 

--- a/src/components/message-pane/message-item/MessageItem.tsx
+++ b/src/components/message-pane/message-item/MessageItem.tsx
@@ -114,7 +114,7 @@ interface FloatingOptionsProps {
 
 function FloatOptions(props: FloatingOptionsProps) {
   const params = useParams<{ serverId: string }>();
-  const { account, serverMembers, channelProperties } = useStore();
+  const { account, serverMembers, channelProperties, channels } = useStore();
   const { createPortal } = useCustomPortal();
 
   const replyClick = () => {
@@ -146,7 +146,11 @@ function FloatOptions(props: FloatingOptionsProps) {
     return member?.hasPermission?.(ROLE_PERMISSIONS.MANAGE_CHANNELS);
   };
 
-  const isContentType = () => props.message.type === MessageType.CONTENT;
+  const showReply = () => {
+    if (props.message.type !== MessageType.CONTENT) return false;
+    const channel = channels.get(props.message.channelId!);
+    return channel?.canSendMessage(account.user()?.id!);
+  }
 
   return (
     <div class={cn(styles.floatOptions, "floatOptions")}>
@@ -158,7 +162,7 @@ function FloatOptions(props: FloatingOptionsProps) {
       <div class={styles.item} onClick={props.reactionPickerClick}>
         <Icon size={18} name="face" class={styles.icon} />
       </div>
-      <Show when={isContentType()}>
+      <Show when={showReply()}>
         <div class={styles.item} onClick={replyClick}>
           <Icon size={18} name="reply" class={styles.icon} />
         </div>

--- a/src/components/message-pane/message-log-area/MessageLogArea.tsx
+++ b/src/components/message-pane/message-log-area/MessageLogArea.tsx
@@ -1,5 +1,5 @@
 import styles from "./styles.module.scss";
-import { ROLE_PERMISSIONS } from "@/chat-api/Bitwise";
+import { CHANNEL_PERMISSIONS, ROLE_PERMISSIONS } from "@/chat-api/Bitwise";
 import { ServerEvents } from "@/chat-api/EventNames";
 import {
   MessageType,
@@ -861,6 +861,9 @@ function MessageContextMenu(props: MessageContextMenuProps) {
   const params = useParams<{ serverId?: string }>();
   const { createPortal } = useCustomPortal();
   const { account, serverMembers, channels } = useStore();
+
+  const channel = () => channels.get(props.message.channelId!);
+
   const onDeleteClick = () => {
     createPortal?.((close) => (
       <DeleteMessageModal close={close} message={props.message} />
@@ -910,8 +913,14 @@ function MessageContextMenu(props: MessageContextMenuProps) {
     return member?.hasPermission?.(ROLE_PERMISSIONS.MANAGE_CHANNELS);
   };
 
-  const showQuote = () => props.message.type === MessageType.CONTENT;
-  const showReply = () => props.message.type === MessageType.CONTENT;
+  const showQuote = () => {
+    if (props.message.type !== MessageType.CONTENT) return false;
+    return channel()?.canSendMessage(account.user()?.id!);
+  };
+  const showReply = () => {
+    if (props.message.type !== MessageType.CONTENT) return false;
+    return channel()?.canSendMessage(account.user()?.id!);
+  };
 
   const hasReactions = () => props.message?.reactions.length;
   const hasContent = () => props.message.content;


### PR DESCRIPTION
## What does this PR do?

This refactors the logic for disabling the message panel input box, and uses the same logic to disable the floating reply button and the reply and quote context menu options.

## Screenshots

<img height="208" alt="screenshot of floating message options without the reply icon" src="https://github.com/user-attachments/assets/5990513f-5365-457e-a6b1-0be7a9a10b09" />

<img height="352" alt="screenshot of a message context menu without the reply or quote options" src="https://github.com/user-attachments/assets/3365f3ce-b8b1-4e03-aeee-98fe060d5a1f" />

## Did you test your code?

I have tested the permissions and mute-based disabling; I haven't created a new account to test the unverified email case.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ N/A
- [ ] ~~Any new user-facing strings are properly localized~~ N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed channel-level permission APIs to compute effective permissions and determine message-sending ability.
  * Message UI now uses the centralized channel send-permission check.

* **Bug Fixes**
  * Reply and quote actions now respect per-channel send permissions.
  * Improved permission evaluation and fixed a runtime error when removing channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->