### PR TITLE
Autofocus modal inputs and allow using enter to submit

### DIFF
--- a/src/components/home-drawer/add-friend/AddFriendModal.tsx
+++ b/src/components/home-drawer/add-friend/AddFriendModal.tsx
@@ -20,6 +20,8 @@ export default function AddFriendModal(props: { close: () => void }) {
           onText={controller.setUserTag}
           value={controller.userTag()}
           success={controller.success() && t("addFriendModal.requestSent")}
+          onEnter={controller.onSendClick}
+          autofocus
         />
       </Modal.Body>
       <Modal.Footer>

--- a/src/components/moderation-pane/AnnouncePostsModal.tsx
+++ b/src/components/moderation-pane/AnnouncePostsModal.tsx
@@ -33,7 +33,7 @@ export default function AnnouncePostsModal(props: Props) {
   } | null>(null);
   const [requestSent, setRequestSent] = createSignal(false);
 
-  const onDeleteClicked = () => {
+  const onAnnounceClicked = () => {
     if (requestSent()) return;
     setRequestSent(true);
     setError(null);
@@ -57,7 +57,7 @@ export default function AnnouncePostsModal(props: Props) {
       }}
     >
       <Button
-        onClick={onDeleteClicked}
+        onClick={onAnnounceClicked}
         margin={0}
         label={requestSent() ? "Announcing..." : "Announce"}
         color="var(--primary-color)"
@@ -82,6 +82,8 @@ export default function AnnouncePostsModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onAnnounceClicked}
+          autofocus
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/DeleteAnnouncePostsModal.tsx
+++ b/src/components/moderation-pane/DeleteAnnouncePostsModal.tsx
@@ -83,6 +83,8 @@ export default function DeleteAnnouncePostsModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onDeleteClicked}
+          autofocus
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/DeletePostsModal.tsx
+++ b/src/components/moderation-pane/DeletePostsModal.tsx
@@ -80,6 +80,8 @@ export default function DeletePostsModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onDeleteClicked}
+          autofocus
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/DeleteServerModal.tsx
+++ b/src/components/moderation-pane/DeleteServerModal.tsx
@@ -64,6 +64,8 @@ export default function DeleteServerModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onDeleteClick}
+          autofocus
         />
         <Show when={error()}>
           <Text color="var(--alert-color)" size={12}>

--- a/src/components/moderation-pane/DeleteServersModal.tsx
+++ b/src/components/moderation-pane/DeleteServersModal.tsx
@@ -164,6 +164,7 @@ export default function DeleteServersModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onSuspendClicked}
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/EditUserSuspensionModal.tsx
+++ b/src/components/moderation-pane/EditUserSuspensionModal.tsx
@@ -174,6 +174,7 @@ export default function EditUserSuspensionModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onSuspendClicked}
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/ModerationPane.tsx
+++ b/src/components/moderation-pane/ModerationPane.tsx
@@ -1620,6 +1620,7 @@ export function Post(props: {
                   placeholder="Reason"
                   onText={setReason}
                   value={reason()}
+                  onEnter={onSuggestClick}
                 />
               </Show>
             </FlexColumn>

--- a/src/components/moderation-pane/ServerPage.tsx
+++ b/src/components/moderation-pane/ServerPage.tsx
@@ -405,6 +405,7 @@ const SuggestBlock = (props: { serverId: string }) => {
                   placeholder="Reason"
                   onText={setReason}
                   value={reason()}
+                  onEnter={onSuggestClick}
                 />
               </Show>
             </FlexColumn>

--- a/src/components/moderation-pane/ShadowBanUserModal.tsx
+++ b/src/components/moderation-pane/ShadowBanUserModal.tsx
@@ -90,13 +90,14 @@ export default function ShadowBanUserModal(props: Props) {
             ]}
           />
         </div>
-        <Input label="Reason" value={reason()} onText={setReason} />
+        <Input label="Reason" value={reason()} onText={setReason} autofocus />
 
         <Input
           label="Confirm Password"
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onWarnClick}
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/SuspendUsersModal.tsx
+++ b/src/components/moderation-pane/SuspendUsersModal.tsx
@@ -227,6 +227,7 @@ export default function SuspendUsersModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onSuspendClicked}
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/UndoServerDeleteModal.tsx
+++ b/src/components/moderation-pane/UndoServerDeleteModal.tsx
@@ -81,6 +81,8 @@ export default function UndoServerDeleteModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onRestoreClick}
+          autofocus
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/UndoShadowBanUserModal.tsx
+++ b/src/components/moderation-pane/UndoShadowBanUserModal.tsx
@@ -85,6 +85,8 @@ export default function UndoShadowBanUserModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onWarnClick}
+          autofocus
         />
 
         <Show when={error()}>

--- a/src/components/moderation-pane/UnsuspendUsersModal.tsx
+++ b/src/components/moderation-pane/UnsuspendUsersModal.tsx
@@ -78,6 +78,8 @@ export default function UnsuspendUsersModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onUnsuspendClicked}
+          autofocus
         />
         <Show when={error()}>
           <Text color="var(--alert-color)" size={12}>

--- a/src/components/moderation-pane/WarnUserModal.tsx
+++ b/src/components/moderation-pane/WarnUserModal.tsx
@@ -122,6 +122,8 @@ export default function WarnUserModal(props: Props) {
           type="password"
           value={password()}
           onText={setPassword}
+          onEnter={onWarnClick}
+          autofocus
         />
 
         <Show when={error()}>

--- a/src/components/servers/modals/CreateChannelModal.tsx
+++ b/src/components/servers/modals/CreateChannelModal.tsx
@@ -51,6 +51,8 @@ export function CreateChannelModal(props: {
           onText={setName}
           value={name()}
           error={error().message}
+          onEnter={onCreateClick}
+          autofocus
         />
       </Modal.Body>
       <Modal.Footer>

--- a/src/components/side-pane/add-server-modal/AddServerModal.tsx
+++ b/src/components/side-pane/add-server-modal/AddServerModal.tsx
@@ -66,6 +66,8 @@ const CreateServerModal = (props: { close: () => void }) => {
           value={controller.name()}
           error={controller.error().message}
           placeholder={t("createServerModal.placeholder")}
+          onEnter={controller.onCreateClick}
+          autofocus
         />
       </Modal.Body>
       <Modal.Footer>
@@ -100,6 +102,7 @@ function sanitizeInviteInput(value: string): string {
 const JoinServerModal = (props: { close: () => void }) => {
   const controller = useAddServerModalController();
   const [rawInvite, setRawInvite] = createSignal(controller.name());
+  const [buttonRef, setButtonRef] = createSignal<HTMLButtonElement>();
 
   return (
     <>
@@ -124,6 +127,8 @@ const JoinServerModal = (props: { close: () => void }) => {
           onText={setRawInvite}
           value={rawInvite()}
           error={controller.error().message}
+          onEnter={() => buttonRef()?.click()}
+          autofocus
         />
       </Modal.Body>
       <Modal.Footer>
@@ -134,7 +139,8 @@ const JoinServerModal = (props: { close: () => void }) => {
           onClick={props.close}
         />
         <Modal.Button
-          onClick={(e) => {
+          ref={setButtonRef}
+          onClick={(e: Event) => {
             const cleaned = sanitizeInviteInput(rawInvite());
             controller.setName(cleaned);
             controller.onJoinClick(e);

--- a/src/components/side-pane/add-server-modal/useAddServerModalController.tsx
+++ b/src/components/side-pane/add-server-modal/useAddServerModalController.tsx
@@ -32,7 +32,7 @@ const useController = (close: () => void) => {
     }, 1000);
   };
 
-  const onJoinClick = async (event: MouseEvent) => {
+  const onJoinClick = async (event: Event) => {
     if (!name().trim()) {
       event.stopPropagation();
       event.preventDefault();

--- a/src/components/ui/delete-confirm-modal/DeleteConfirmModal.tsx
+++ b/src/components/ui/delete-confirm-modal/DeleteConfirmModal.tsx
@@ -103,6 +103,8 @@ export default function DeleteConfirmModal(props: Props) {
             type={props.password ? "password" : "text"}
             error={error()}
             onText={(v) => setConfirmInput(v)}
+            onEnter={onDeleteClick}
+            autofocus
           />
         </Show>
       </div>

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -23,9 +23,6 @@ interface Props {
   label?: string;
   type?: string;
   value?: string;
-  onText?: (value: string) => void;
-  onBlur?(event: FocusEvent): void;
-  onFocus?(event: FocusEvent): void;
   error?: Error | string | null;
   success?: string | false;
   errorName?: string | string[];
@@ -38,11 +35,16 @@ interface Props {
   ref?: (el: HTMLInputElement | HTMLTextAreaElement) => void;
   margin?: number | number[];
   maxLength?: number;
-  onInput?: (event: InputEvent) => void;
   primaryColor?: string;
-  onChange?: JSX.ChangeEventHandlerUnion<HTMLInputElement, Event>;
   disabled?: boolean;
+  autofocus?: boolean;
+  onBlur?(event: FocusEvent): void;
+  onFocus?(event: FocusEvent): void;
   onClick?: (event: MouseEvent) => void;
+  onInput?: (event: InputEvent) => void;
+  onText?: (value: string) => void;
+  onChange?: JSX.ChangeEventHandlerUnion<HTMLInputElement, Event>;
+  onEnter?: (event: KeyboardEvent) => void;
 }
 
 const Base = styled("div")<{ margin?: number | number[] }>`
@@ -136,6 +138,9 @@ export default function Input(props: Props) {
 
   onMount(() => {
     props.ref?.(inputEl as HTMLInputElement | HTMLTextAreaElement);
+    if (props.autofocus) {
+      focus();
+    }
   });
 
   const error = () => {
@@ -194,6 +199,17 @@ export default function Input(props: Props) {
     setFocused(true);
     props.onFocus?.(event);
   };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      if (event.shiftKey) return;
+      if (props.onEnter) {
+        event.preventDefault();
+        props.onEnter(event);
+      }
+    }
+  };
+
   return (
     <Base margin={props.margin} class={props.class}>
       <Show when={props.label}>
@@ -221,6 +237,7 @@ export default function Input(props: Props) {
             onfocus={onFocus}
             onblur={onBlur}
             onInput={onChange}
+            onkeydown={onKeyDown}
             value={props.value || ""}
           />
         </Show>
@@ -234,6 +251,7 @@ export default function Input(props: Props) {
             onfocus={onFocus}
             onblur={onBlur}
             onInput={onChange}
+            onkeydown={onKeyDown}
             type={props.type || "text"}
             value={props.value || ""}
             onClick={props.onClick}


### PR DESCRIPTION
## What does this PR do?

This goes through most of the single-input modals and makes the text inputs autofocus.  In addition, for modals where it makes sense, it makes enter on that input field trigger the primary modal action.

At some point modals should be refactored so that this is automatic / requires less boilerplate, but for now this approach is fine.

I can move the changes to the moderation modals to a separate PR if that makes it easier to review/merge.

## Screenshots
None for now.

## Did you test your code?

I've tested the modals I can access without setting up a custom backend, but a large portion of the modals are moderator only.  Then *should* all work, but it would be good to test them; I'll set up a backend server and test them at some point, so don't feel the need to test or review this now if you don't feel like it.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input fields in modals now auto-focus on render for improved accessibility
  * Users can press Enter to submit forms and trigger actions across modals—including friend requests, server management, and moderation tasks—eliminating the need to click buttons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->