### PR TITLE
Work around Firefox image sizing bug in activity list

### DIFF
--- a/src/components/DashboardPane.tsx
+++ b/src/components/DashboardPane.tsx
@@ -386,6 +386,7 @@ const ActivityList = () => {
     if (!activityListEl) return;
     event.preventDefault();
     activityListEl.scrollLeft += event.deltaY;
+    activityListEl.scrollLeft += event.deltaX;
   };
 
   const activities = () => {
@@ -478,6 +479,7 @@ const textOverflowHiddenStyles = css`
 const activityImageStyles = css`
   aspect-ratio: 1/1;
   height: 100%;
+  max-width: 100px;
   object-fit: contain;
   border-radius: 6px;
 


### PR DESCRIPTION
Works around a really weird sizing bug in Firefox in the activity list -- the activity container is set to the native image width, despite the image only ending up being 80 pixels wide.

(This also allows horizontal scrolling in the activity list, for touchpad users.)

## Screenshots
Before:
https://github.com/user-attachments/assets/29cbf440-9c52-48c0-a7d4-2b7876f4c099

After:
https://github.com/user-attachments/assets/5cbaf8dd-ab74-416c-9c59-4c85a3153908

## Did you test your code?

Yes; this only occurs on Firefox, and the max-width is slightly larger than the normal width, so it doesn't change the image sizes.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ N/A
- [ ] ~~Any new user-facing strings are properly localized~~ N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled horizontal scrolling with the mouse wheel on the dashboard.

* **Bug Fixes**
  * Fixed activity image display to prevent overflow by constraining maximum width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->