### PR TITLE
Fix alert handles in inbox list

### DIFF
--- a/src/components/home-drawer/friend-item/HomeDrawerFriendItem.tsx
+++ b/src/components/home-drawer/friend-item/HomeDrawerFriendItem.tsx
@@ -99,9 +99,7 @@ export default function HomeDrawerFriendItem(props: {
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
         selected={props.isInboxTab && !isBlocked() && isSelected()}
-        handleColor={
-          mentionCount() || showAccept() ? "var(--alert-color)" : undefined
-        }
+        alert={mentionCount() > 0 || showAccept()}
         onClick={onFriendClick}
       >
         <A href={RouterEndpoints.PROFILE(user().id)} class="link">

--- a/src/components/ui/Item.module.scss
+++ b/src/components/ui/Item.module.scss
@@ -1,5 +1,8 @@
 .itemRoot {
   --handle-color: var(--primary-color);
+  --handle-length: 8px;
+  --handle-thickness: 4px;
+
   position: relative;
   display: flex;
   align-items: center;
@@ -20,44 +23,42 @@
     .label {
       opacity: 1;
     }
- 
   }
 
-  &:after {
+  &::after {
     position: absolute;
     left: 0;
-    width: 4px;
-    height: 8px;
+    width: var(--handle-thickness);
+    height: var(--handle-length);
     border-radius: 9999px;
     content: "";
     transition: 0.2s;
   }
   
   &[data-handle-position="bottom"]{
-    &::after  {
+    &::after {
       bottom: 0;
       left: initial;
-      width: 8px;
-      height: 4px;
+      width: var(--handle-length);
+      height: var(--handle-thickness);
     }
   }
   
   &[data-selected="true"] {
     background-color: hsl(216deg 7% 28% / 60%);
+    --handle-length: 16px;
     &:after {
-      height: 16px;
       background-color: var(--handle-color);
-    }
-    &[data-handle-position="bottom"]{
-      &::after  {
-        bottom: 0;
-        left: initial;
-        width: 16px;
-        height: 4px;
-      }
     }
     .label {
       opacity: 1;
+    }
+  }
+
+  &[data-alert="true"] {
+    --handle-length: 16px;
+    &:after {
+      background-color: var(--alert-color);
     }
   }
 }

--- a/src/components/ui/Item.tsx
+++ b/src/components/ui/Item.tsx
@@ -8,12 +8,14 @@ import { cn } from "@/common/classNames";
 interface RootProps {
   children?: JSXElement;
   selected?: boolean;
+  alert?: boolean;
   handlePosition?: "bottom" | "left";
   onClick?: (e?: MouseEvent) => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   href?: string;
   handleColor?: string;
+  alertColor?: string;
   gap?: number;
   class?: string;
 }
@@ -23,7 +25,11 @@ const Root = (props: RootProps) => (
     href={props.href}
     class={cn(style.itemRoot, props.class)}
     data-selected={props.selected}
-    style={{ "--handle-color": props.handleColor }}
+    data-alert={props.alert}
+    style={{
+      "--handle-color": props.handleColor,
+      "--alert-color": props.alertColor,
+    }}
     onClick={props.onClick}
     data-handle-position={props.handlePosition || "left"}
     onMouseEnter={props.onMouseEnter}


### PR DESCRIPTION
This re-adds alert handles in the inbox list.  It also refactors the handle CSS to use length/thickness variables for the handles, so that both left and bottom handles use the same logical dimensions.

## Screenshots
Before:
<img height="79" src="https://github.com/user-attachments/assets/6a1e7ac6-870a-4890-8b8e-5adaf2820f5f" />

After:
<img height="77" src="https://github.com/user-attachments/assets/64204db3-6078-4aac-b626-c969ed413ba3" />

## Did you test your code?
Tested on desktop Firefox and Chrome on android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Friend items now show a clear alert state for mentions or pending requests to draw attention.

* **Style**
  * Refined handle sizing and spacing with responsive tokens.
  * Added distinct alert styling and color treatment for highlighted items for better visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->