### PR TITLE
Fix styling of "N more" in reaction hover popup

### DIFF
--- a/src/components/message-pane/message-item/Reactions.tsx
+++ b/src/components/message-pane/message-item/Reactions.tsx
@@ -250,7 +250,9 @@ function WhoReactedModal(props: {
           )}
         </For>
         <Show when={plusCount()}>
-          {t("message.reactions.more", { count: plusCount() })}
+          <div class={style.whoReactedPlusCount}>
+            {t("message.reactions.more", { count: plusCount() })}
+          </div>
         </Show>
       </div>
     </Show>


### PR DESCRIPTION
## What does this PR do?

Applies existing styles for the "N more" text at the bottom of the reaction hover modal, which were unintentionally not applied.

## Screenshots
Before:
<img height="228" alt="image" src="https://github.com/user-attachments/assets/c3f38c3e-c804-4e6a-86e4-5588a0ce2353" />

After:
<img height="231" alt="image" src="https://github.com/user-attachments/assets/17d80723-56c2-471d-837f-771dbba1cb73" />

## Did you test your code?
Yes.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling and layout structure for reaction count displays in modal interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->