### PR TITLE
Fix header icon positioning, re-add shadow on layered icons

### DIFF
--- a/src/components/main-pane-header/MainPaneHeader.tsx
+++ b/src/components/main-pane-header/MainPaneHeader.tsx
@@ -152,18 +152,20 @@ export default function MainPaneHeader() {
             onClick={toggleLeftDrawer}
           />
         </div>
-        {header.details().iconName && (
-          <Icon
-            size={24}
-            name={header.details().iconName}
-            class={classNames(
-              styles.icon,
-              conditionalClass(server() || user(), styles.hasAvatar)
-            )}
-          />
-        )}
-        {server() && <Avatar size={28} server={server()} />}
-        {user() && <Avatar class={styles.avatar} size={28} user={user()} />}
+        <div class={styles.iconContainer}>
+          {server() && <Avatar size={28} server={server()} />}
+          {user() && <Avatar class={styles.avatar} size={28} user={user()} />}
+          {header.details().iconName && (
+            <Icon
+              size={24}
+              name={header.details().iconName}
+              class={classNames(
+                styles.icon,
+                conditionalClass(server() || user(), styles.hasAvatar)
+              )}
+            />
+          )}
+        </div>
         <div class={styles.details}>
           <div class={styles.title}>{details().title}</div>
           {details().subName && (

--- a/src/components/main-pane-header/styles.module.scss
+++ b/src/components/main-pane-header/styles.module.scss
@@ -25,17 +25,6 @@
   user-select: none;
   transition: 0.2s;
   backdrop-filter: blur(34px);
-  .avatar {
-    position: relative;
-    z-index: 1;
-  }
-  .icon {
-    position: relative;
-    z-index: 1111111111111111111111111111111111111;
-  }
-  .icon.hasAvatar {
-    left: 70px;
-  }
 }
 
 .toggleLeftDrawerContainer {
@@ -80,14 +69,17 @@
   font-size: 12px;
 }
 
+.iconContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
 .icon.hasAvatar {
   position: absolute;
   z-index: 1;
-  z-index: 1111;
-  top: 26px;
-  left: 25px;
-  text-shadow: 0px 0px 5px black;
-  font-size: 11px;
+  right: -8px;
+  bottom: -8px;
+  filter: drop-shadow(0px 0px 5px black);
 }
 
 .rightIcons {


### PR DESCRIPTION
This fixes the header icon positions so that sub-icons don't overlap with content next to the icon, and re-enables the shadow that was lost when icons were switched from font-based to SVG based.

This PR doesn't change the icon sizes for the sub-icons, but that would be reasonable to do.  (The font version changed the font size, but I don't know what the intended size was.)

## Screenshots
Here's every header icon combination (except for moderation ones); pairs of headers, with the current rendering on the top and the fixed version on the bottom.

<img height="704" src="https://github.com/user-attachments/assets/a0303196-687a-4afc-b79c-144a8c54ef0d" />

## Did you test your code?
I've tested on Firefox on desktop and on Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review
- [x] Code has been tested and works as intended
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized header icon and avatar layout for improved positioning and visual presentation.
  * Enhanced icon badge styling with refined placement and shadow effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->