### PR TITLE
Remove accidental padding around server settings drawer header

### DIFF
--- a/src/components/servers/settings/ServerSettingsDrawer.tsx
+++ b/src/components/servers/settings/ServerSettingsDrawer.tsx
@@ -23,7 +23,6 @@ const MainContainer = styled(FlexColumn)`
   padding-right: 4px;
 `;
 const SettingsListContainer = styled("div")`
-  padding-top: 4px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -53,6 +52,7 @@ const SettingItemContainer = styled(ItemContainer)<{ nested?: boolean }>`
 export default function ServerSettingsDrawer() {
   return (
     <>
+      <ServerDrawerHeader />
       <MainContainer>
         <SettingsList />
         <Footer />
@@ -75,29 +75,26 @@ function SettingsList() {
   };
 
   return (
-    <>
-      <ServerDrawerHeader />
-      <SettingsListContainer>
-        <For each={serverSettings}>
-          {(setting) => {
-            if (setting.hideDrawer) return null;
-            const selected = () => params.path === setting.path;
-            // const isChannels = () => setting.path === "channels";
-            return (
-              <Show when={hasPermission(setting.requiredRolePermission)}>
-                <Item
-                  path={setting.path || "#  "}
-                  icon={setting.icon}
-                  label={setting.name()}
-                  selected={selected()}
-                />
-                {/* <Show when={isChannels() && selected()}><ServerChannelsList/></Show> */}
-              </Show>
-            );
-          }}
-        </For>
-      </SettingsListContainer>
-    </>
+    <SettingsListContainer>
+      <For each={serverSettings}>
+        {(setting) => {
+          if (setting.hideDrawer) return null;
+          const selected = () => params.path === setting.path;
+          // const isChannels = () => setting.path === "channels";
+          return (
+            <Show when={hasPermission(setting.requiredRolePermission)}>
+              <Item
+                path={setting.path || "#  "}
+                icon={setting.icon}
+                label={setting.name()}
+                selected={selected()}
+              />
+              {/* <Show when={isChannels() && selected()}><ServerChannelsList/></Show> */}
+            </Show>
+          );
+        }}
+      </For>
+    </SettingsListContainer>
   );
 }
 


### PR DESCRIPTION
This moves the settings drawer header in the DOM to match the other drawers, which fixes some padding bugs.

## Screenshots
It's hard to see directly, but there's a visible gap around the drawer header.  (Open both in new tabs and switch between them to see.)  I've included a screenshot of the account settings page for reference.

Before:
<img height="507" alt="settings-header-bug" src="https://github.com/user-attachments/assets/cbf2b94d-9007-413e-a860-8598c8b3721e" />

After:
<img height="507" alt="settings-header-fixed" src="https://github.com/user-attachments/assets/9dcf25b5-e8e4-4fa0-a465-e03622e426dc" />

<details>
<summary>Account settings for reference</summary>
<img height="507" alt="settings-header-example" src="https://github.com/user-attachments/assets/b700cb87-7703-4b1e-b05d-925b6b98130e" />
</details>

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted server settings drawer layout: header is now rendered at the top of the drawer and top spacing was reduced for tighter visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->