### PR TITLE
i18n: Translate Screenshare and Webcam modals

### DIFF
--- a/src/components/main-pane-header/ScreenShareModal.tsx
+++ b/src/components/main-pane-header/ScreenShareModal.tsx
@@ -16,6 +16,7 @@ import { ElectronCaptureSource, electronWindowAPI } from "@/common/Electron";
 import { useParams } from "solid-navigator";
 import { hasBit, USER_BADGES } from "@/chat-api/Bitwise";
 import Checkbox from "../ui/Checkbox";
+import { t } from "@nerimity/i18lite";
 
 const QualityOptions = ["480p", "720p", "1080p"] as const;
 const FramerateOptions = ["1fps 💀", "10fps", "30fps", "60fps"] as const;
@@ -135,18 +136,18 @@ export function ScreenShareModal(props: { close: () => void }) {
 
   const ActionButtons = (
     <ActionButtonsContainer>
-      <Button label="Back" color="var(--alert-color)" onClick={props.close} />
-      <Button label="Choose Window" onClick={chooseWindowClick} />
+      <Button label={t("general.backButton")} color="var(--alert-color)" onClick={props.close} />
+      <Button label={t("mainPaneHeader.voice.screenShareModal.chooseWindowButton")} onClick={chooseWindowClick} />
     </ActionButtonsContainer>
   );
 
   return (
     <LegacyModal
-      title="Screen Share"
+      title={t("mainPaneHeader.voice.screenShareModal.title")}
       close={props.close}
       actionButtons={ActionButtons}
     >
-      <OptionTitle>Quality</OptionTitle>
+      <OptionTitle>{t("mainPaneHeader.voice.screenShareModal.quality")}</OptionTitle>
       <OptionContainer>
         <For each={QualityOptions}>
           {(quality) => (
@@ -161,7 +162,7 @@ export function ScreenShareModal(props: { close: () => void }) {
         </For>
       </OptionContainer>
 
-      <OptionTitle>Framerate</OptionTitle>
+      <OptionTitle>{t("mainPaneHeader.voice.screenShareModal.framerate")}</OptionTitle>
       <OptionContainer>
         <For each={FramerateOptions}>
           {(framerate) => (
@@ -180,8 +181,8 @@ export function ScreenShareModal(props: { close: () => void }) {
           label={
             navigator?.userAgentData?.platform !== "Windows" ||
             electronSourceId()?.includes("screen")
-              ? "Share System Audio"
-              : "Share App Audio"
+              ? t("mainPaneHeader.voice.screenShareModal.shareSystemAudio")
+              : t("mainPaneHeader.voice.screenShareModal.shareAppAudio")
           }
           checked={shareSystemAudio()}
           onChange={setShareSystemAudio}

--- a/src/components/main-pane-header/WebcamModal.tsx
+++ b/src/components/main-pane-header/WebcamModal.tsx
@@ -6,6 +6,7 @@ import { FlexRow } from "../ui/Flexbox";
 import useStore from "@/chat-api/store/useStore";
 import DropDown, { DropDownItem } from "../ui/drop-down/DropDown";
 import { toast } from "../ui/custom-portal/CustomPortal";
+import { t } from "@nerimity/i18lite";
 
 const ActionButtonsContainer = styled(FlexRow)`
   justify-content: flex-end;
@@ -57,7 +58,7 @@ export function WebcamModal(props: { close: () => void }) {
       })
       .catch((err) => {
         console.error(err);
-        toast("Failed to share camera");
+        toast(t("mainPaneHeader.voice.webcamModal.error"));
       });
     if (!stream) return;
     voiceUsers.setVideoStream(stream);
@@ -66,13 +67,13 @@ export function WebcamModal(props: { close: () => void }) {
 
   const ActionButtons = (
     <ActionButtonsContainer>
-      <Button label="Back" color="var(--alert-color)" onClick={props.close} />
-      <Button label="Share Camera" onClick={shareCameraClick} />
+      <Button label={t("general.backButton")} color="var(--alert-color)" onClick={props.close} />
+      <Button label={t("mainPaneHeader.voice.webcamModal.shareCameraButton")} onClick={shareCameraClick} />
     </ActionButtonsContainer>
   );
 
   const dropdownItems: () => DropDownItem[] = () => [
-    { id: "default", label: "Default" },
+    { id: "default", label: t("settings.call.default") },
     ...devices().map((device) => ({
       id: device.deviceId,
       label: device.label
@@ -81,7 +82,7 @@ export function WebcamModal(props: { close: () => void }) {
 
   return (
     <LegacyModal
-      title="Share Webcam"
+      title={t("mainPaneHeader.voice.webcamModal.title")}
       close={props.close}
       actionButtons={ActionButtons}
     >

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1044,7 +1044,20 @@
       "leave": "Leave",
       "muted": "Muted",
       "deafened": "Deafened",
-      "fullscreen": "Fullscreen"
+      "fullscreen": "Fullscreen",
+      "webcamModal": {
+        "title": "Webcam Share",
+        "error": "Failed to share camera",
+        "shareCameraButton": "Share Camera"
+      },
+      "screenShareModal": {
+        "title": "Screen Share",
+        "quality": "Quality",
+        "framerate": "Framerate",
+        "shareSystemAudio": "Share System Audio",
+        "shareAppAudio": "Share App Audio",
+        "chooseWindowButton": "Choose Window"
+      }
     }
   },
   "channelDrawer": {


### PR DESCRIPTION
## What does this PR do?
- Translates Webcam and Screenshare popups

## Screenshots
<img width="268" height="233" alt="Здымак экрана ад 2026-02-20 19-58-03" src="https://github.com/user-attachments/assets/52c9dcb9-6bba-45cf-87ca-aefb3fa6bbe4" />
<img width="268" height="233" alt="Здымак экрана ад 2026-02-20 19-58-44" src="https://github.com/user-attachments/assets/a977ba16-7995-4322-b5cd-255d52d65572" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Screen sharing modal now fully supports multiple languages with translated titles, window selection buttons, quality and framerate options, and system/app audio sharing controls.
  * Webcam modal updated with comprehensive internationalization support for modal titles, action buttons, dropdown options, and error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->