### PR TITLE
Use native language name and flag in language dropdown

### DIFF
--- a/src/components/PageFooter.tsx
+++ b/src/components/PageFooter.tsx
@@ -10,6 +10,9 @@ import {
 } from "@/locales/languages";
 import { useTransContext } from "@nerimity/solid-i18lite";
 import { appLogoUrl } from "@/common/worldEvents";
+import { emojiUnicodeToShortcode, unicodeToTwemojiUrl } from "@/emoji";
+import { Emoji } from "./markup/Emoji";
+import { JSXElement } from "solid-js";
 
 const FooterContainer = styled(FlexRow)`
   gap: 10px;
@@ -100,10 +103,31 @@ export default function PageFooter() {
 const LanguageDropdown = () => {
   const [, actions] = useTransContext();
 
-  const items: DropDownItem[] = Object.keys(languages).map((key) => ({
-    id: key.replace("-", "_"),
-    label: languages[key as keyof typeof languages].name
-  }));
+  const items: DropDownItem[] = Object.keys(languages).map((key) => {
+    let lang = languages[key as keyof typeof languages]!;
+    return {
+      id: key.replace("-", "_"),
+      // Use a getter to create a new element, as reused JSXElements
+      // break the dropdown DOM.
+      get label(): JSXElement {
+        return (
+          <>
+            <Emoji
+              class={css`
+                height: 22px;
+                width: 22px;
+                align-self: flex-start;
+                margin-right: 6px;
+              `}
+              name={emojiUnicodeToShortcode(lang.emoji)}
+              url={unicodeToTwemojiUrl(lang.emoji)}
+            />
+            <span>{lang.nativeName ?? lang.name}</span>
+          </>
+        )
+      }
+    }
+  });
 
   const currentLanguage = () => getCurrentLanguage() || "en-gb";
 


### PR DESCRIPTION
This makes the language dropdown on the landing page use the native language name if available, and adds flags to the dropdown.

## Screenshots
<img height="73" alt="image" src="https://github.com/user-attachments/assets/21e229e2-231a-4353-95e4-867434a6d817" />
<img height="335" alt="image" src="https://github.com/user-attachments/assets/92c82171-d70b-402d-8ccf-303fb62b8720" />

## Did you test your code?

Yes; tested on Firefox on desktop and Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Language selection dropdown now displays emoji icons alongside language names for enhanced visual identification and easier language selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->