### PR TITLE
i18n: Translate new call options

### DIFF
--- a/src/components/settings/CallSettings.tsx
+++ b/src/components/settings/CallSettings.tsx
@@ -89,26 +89,24 @@ function InputDevices() {
     const supportedList: AvailableConstraint[] = [];
     if (supported.echoCancellation)
       supportedList.push({
-        label: "Echo Cancellation",
-        description:
-          "Prevents the microphone from picking up sound from the speakers.",
+        label: t("settings.call.inputConstraints.echoCancelation"),
+        description: t("settings.call.inputConstraints.echoCancelationDescription"),
         icon: "record_voice_over",
         key: "echo",
         default: true
       });
     if (supported.noiseSuppression)
       supportedList.push({
-        label: "Noise Suppression",
-        description: "Filters out constant background noise (fans, hums).",
+        label: t("settings.call.inputConstraints.noiseSuppression"),
+        description: t("settings.call.inputConstraints.noiseSuppressionDescription"),
         icon: "noise_aware",
         key: "noise",
         default: true
       });
     if (supported.autoGainControl)
       supportedList.push({
-        label: "Auto Gain Control",
-        description:
-          "Automatically adjusts volume levels to maintain a consistent signal.",
+        label: t("settings.call.inputConstraints.autoGainControl"),
+        description: t("settings.call.inputConstraints.autoGainControlDescription"),
         icon: "settings_voice",
         key: "gain",
         default: true
@@ -379,8 +377,8 @@ function TurnServers() {
   );
   return (
     <SettingsBlock
-      label="Use Cloudflare TURN Servers"
-      description="Use TURN servers for better connectivity"
+      label={t("settings.call.useTurn")}
+      description={t("settings.call.useTurnDescription")}
       icon="cloud"
       onClick={() => setEnabled(!enabled())}
     >

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -682,12 +682,22 @@
       "inputDevices": "Input Devices",
       "outputDevices": "Output Devices",
       "default": "System Default",
+      "inputConstraints": {
+        "echoCancelation": "Echo Cancellation",
+        "echoCancelationDescription": "Prevents the microphone from picking up sound from the speakers.",
+        "noiseSuppression": "Noise Suppression",
+        "noiseSuppressionDescription": "Filters out constant background noise (fans, hums).",
+        "autoGainControl": "Auto Gain Control",
+        "autoGainControlDescription": "Automatically adjusts volume levels to maintain a consistent signal."
+      },
       "inputMode": "Input Mode",
       "openMic": "Open Mic",
       "voiceActivity": "Voice Activity",
       "pushToTalk": "Push to Talk",
       "bindButton": "Bind",
       "stopButton": "Stop",
+      "useTurn": "Use Cloudflare TURN Servers",
+      "useTurnDescription": "Use TURN servers for better connectivity",
       "downloadAppNotice": "Download the Nerimity desktop app to use this feature without window tab focus."
     },
     "connections": {

--- a/src/locales/list/en-us.json
+++ b/src/locales/list/en-us.json
@@ -27,6 +27,11 @@
             "inAppPreview": "In App Preview",
             "inAppPreviewDescription": "Display In App Notification popups."
         },
+        "call": {
+            "inputConstraints": {
+                "echoCancelation": "Echo Cancelation"
+            }
+        },
         "connections": {
             "thirdParty": {
                 "unauthorizeButton": "Unauthorize",


### PR DESCRIPTION
## What does this PR do?
- Translates new settings in call category

## Screenshots
<img width="899" height="695" alt="image" src="https://github.com/user-attachments/assets/e6a59734-aea5-49e6-907b-583646d78c6b" />

## Did you test your code?
Yes

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Localized call settings labels and descriptions for Echo Cancellation, Noise Suppression, Auto Gain Control, and TURN Server options across supported language variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->