### PR TITLE
feat: add edit profile button to user's full page profile

### DIFF
--- a/src/components/profile-pane/ProfilePane.tsx
+++ b/src/components/profile-pane/ProfilePane.tsx
@@ -437,6 +437,7 @@ const ActionButtons = (props: {
   user?: RawUser | null;
   primaryColor?: string;
 }) => {
+  const navigate = useNavigate();
   const params = useParams<{ userId: string }>();
   const { friends, users, account } = useStore();
 
@@ -603,6 +604,16 @@ const ActionButtons = (props: {
         color={props.primaryColor || "var(--primary-color)"}
         onClick={onMessageClicked}
       />
+
+      <Show when={isMe()}>
+        <ActionButton
+          icon="settings"
+          label={t("profile.personal.editProfile")}
+          color={props.primaryColor || "var(--primary-color)"}
+          onClick={() => navigate("/app/settings/account")}
+        />
+      </Show>
+
       <ActionButton
         icon="more_vert"
         color={props.primaryColor || "var(--primary-color)"}


### PR DESCRIPTION
Add an "Edit profile" button to the user's own full profile page, to match the floating profile.

## Screenshots

<img height="570" alt="image" src="https://github.com/user-attachments/assets/ab6e936b-8c52-497c-9732-2775e763df50" />
<img height="495" alt="image" src="https://github.com/user-attachments/assets/413d20e0-bcae-4118-bee6-9f890d75b6eb" />

It does not appear on other users:
<img height="540" alt="image" src="https://github.com/user-attachments/assets/59c230fe-325c-4f2a-a734-6e638a0e71b1" />

<details>
<summary>Current views, for comparison</summary>

<img height="495" alt="image" src="https://github.com/user-attachments/assets/c058c2c8-0092-4ecd-b1f6-8c0aee90c4a4" />
<img height="567" alt="image" src="https://github.com/user-attachments/assets/bf6d9995-a0a9-4d91-bcb1-6d8d2c34a6b6" />

</details>

## Did you test your code?
Tested on Firefox on Desktop and Chrome on mobile.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Edit Profile button to the profile pane that appears only for the profile owner. Clicking the button navigates to the account settings page, enabling users to modify their profile information directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->