### PR TITLE
feat: add link to full notification settings in server context menu

### DIFF
--- a/src/components/servers/context-menu/ContextMenuServer.tsx
+++ b/src/components/servers/context-menu/ContextMenuServer.tsx
@@ -229,6 +229,17 @@ export default function ContextMenuServer(props: Props) {
       })
     );
 
+    items.push(
+      {
+        icon: "settings",
+        label: t("settings.drawer.title"),
+        onClick: () =>
+          navigate(
+            RouterEndpoints.SERVER_SETTINGS_NOTIFICATIONS(props.serverId!)
+          ),
+      }
+    );
+
     return items;
   };
 


### PR DESCRIPTION
This adds a link to the full user notification settings page for a sever to the server notification sub-menu.  (This page has notification settings for each channel, so it's not redundant.)

Currently, clicking the notification submenu label opens the notification settings page, but that isn't discoverable and isn't something most users would expect.  Adding an explicit settings menu item makes it easier to discover.

This currently reuses the translation string for settings from the server context menu, but it could be good to have a specific string for notification settings.

## Screenshots
<img height="427" alt="image" src="https://github.com/user-attachments/assets/8b0eb381-bfb5-45f5-85a2-f8346e5ecea5" />
<img height="535" src="https://github.com/user-attachments/assets/c051147a-40a3-4c90-9303-9cb2afd6a964" />

## Did you test your code?
Tested on Firefox on Linux and Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings shortcut to the server context menu, providing quick access to server notification preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->