### PR TITLE
fix: always animate emoji in emoji details modal

### DIFF
--- a/src/components/markup/Emoji.tsx
+++ b/src/components/markup/Emoji.tsx
@@ -105,7 +105,6 @@ function EmojiDetailsModal(props: {
     null
   );
   const { shouldAnimate } = useWindowProperties();
-  const [hovered, setHovered] = createSignal(false);
 
   onMount(() => {
     if (!props.custom || !props.id) return;
@@ -120,8 +119,6 @@ function EmojiDetailsModal(props: {
       <EmojiDetailsContainer>
         <MainEmojiContainer>
           <img
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
             loading="lazy"
             style={{
               "object-fit": "contain",
@@ -130,7 +127,7 @@ function EmojiDetailsModal(props: {
               "border-radius": "6px",
             }}
             src={
-              props.url + (props.animated && !shouldAnimate(hovered()) ? "?type=webp" : "")
+              props.url + (props.animated && !shouldAnimate(true) ? "?type=webp" : "")
             }
             alt={props.name}
             title={props.name}


### PR DESCRIPTION
This makes animated emojis always play in the emoji details modal, even when reduced motion is enabled.

## Screenshots

Desktop:
https://github.com/user-attachments/assets/819d3e6f-2abe-4b3f-b6b1-c57c496cdc3a
Mobile:
https://github.com/user-attachments/assets/2f5ba07e-6968-4944-9f27-109985e76fe7

## Did you test your code?
Tested on chrome on mobile & firefox on desktop.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized
