### PR TITLE
chore: remove unused FormData in cdn upload

### DIFF
--- a/src/chat-api/services/nerimityCDNService.ts
+++ b/src/chat-api/services/nerimityCDNService.ts
@@ -85,9 +85,6 @@ function nerimityCDNUploadRequest(opts: {
 }
 
 function nerimityCDNRequest(opts: NerimityCDNRequestOpts) {
-  const formData = new FormData();
-  formData.append("attachment", opts.file);
-
   return request<{ fileId: string }>({
     method: "POST",
     url: opts.url,


### PR DESCRIPTION
This is just removing the dead code I found when trying to understand the CDN upload process.