### PR TITLE
fix: limit tag input length, make width based on font size

### DIFF
--- a/src/components/settings/AccountSettings.tsx
+++ b/src/components/settings/AccountSettings.tsx
@@ -413,9 +413,10 @@ export function EditAccountPage(props: {
       <SettingsBlock icon="sell" label={t("settings.account.tag")}>
         <Input
           class={css`
-            width: 52px;
+            width: 5em;
           `}
           value={inputValues().tag}
+          maxLength={4}
           onText={(v) => setInputValue("tag", v)}
         />
       </SettingsBlock>


### PR DESCRIPTION
This uses a font-relative width for the tag input, so it should always be wide enough; and adds a native length limit of 4 characters to the tag inpuot.

## Screenshots
Mobile:
Fixed:
<img height="208" src="https://github.com/user-attachments/assets/2942fbd2-e914-40d6-8b97-639e21c418dc" />
Current:
<img height="206" src="https://github.com/user-attachments/assets/56461eb6-b577-4022-b61e-abd42ccb4109" />

Desktop:
Fixed:
<img height="210" src="https://github.com/user-attachments/assets/fc3333b9-9bc2-47d7-8703-7a79e7fcabe9" />
Current:
<img height="201" src="https://github.com/user-attachments/assets/f1aa9a31-da31-4ce0-9140-fdb6d13f425b" />

## Did you test your code?
Tested on Firefox on desktop and Chrome on android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized
