### PR TITLE
fix: fix wrapping for wrap custom invite link input

### DIFF
--- a/src/components/servers/settings/invites/ServerSettingsInvite.tsx
+++ b/src/components/servers/settings/invites/ServerSettingsInvite.tsx
@@ -178,6 +178,8 @@ function CustomInvite(props: { invites: any[]; onUpdate: () => void }) {
           && {
             position: relative;
             overflow: hidden;
+            flex-wrap: wrap;
+            row-gap: 5px;
             ${!server()?.verified ? "cursor: not-allowed; opacity: 0.6;" : ""}
           }
         `}

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -104,6 +104,7 @@ const PrefixLabel = styled(Text)`
   padding-left: 10px;
   margin-right: -10px;
   place-self: center;
+  white-space: nowrap;
 `;
 
 const SuffixLabel = styled(Text)`


### PR DESCRIPTION
This disables wrapping on the prefix in `<Input>`, and makes the custom link input wrap to a new line instead.  This is the only place where `prefix` is used, so the wrapping change doesn't affect anything else.  The prefix appears to only wrap on Firefox, but the width is still an issue on mobile for Chrome.

## Screenshots
Desktop (Firefox):
Fixed:
<img height="261" src="https://github.com/user-attachments/assets/90cdebd9-6011-4847-ae84-c2df45e9cf91" />
Current:
<img height="266" src="https://github.com/user-attachments/assets/acf8380e-4470-43f0-8c20-266eaeec1118" />

Mobile (Firefox):
Fixed:
<img height="321" src="https://github.com/user-attachments/assets/e5541192-d0b0-499e-bf53-08c29583b3aa" />
Current:
<img height="298" src="https://github.com/user-attachments/assets/8bdb0092-eccb-4d18-b911-df6adeadac38" />

## Did you test your code?
Tested on Firefox on desktop, Firefox on mobile, and Chrome on android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout responsiveness for server settings invites with improved content wrapping.
  * Fixed text overflow prevention in input components for better display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->