### PR TITLE
feat: Add edit profile button on user's floating profile banner

### DIFF
--- a/src/components/floating-profile/FloatingProfile.module.scss
+++ b/src/components/floating-profile/FloatingProfile.module.scss
@@ -246,6 +246,32 @@ body .postItemContainer {
   }
 }
 
+.bannerButton {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  border-radius: 6px;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+
+  :global(.label) {
+    max-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    transition: max-width 0.3s;
+    margin-left: 0 !important;
+  }
+
+  &:hover :global(.label) {
+    max-width: 100px;
+    margin-left: 5px !important;
+  }
+}
+
 .playedFor {
   font-variant-numeric: tabular-nums;
 }

--- a/src/components/floating-profile/FloatingProfile.tsx
+++ b/src/components/floating-profile/FloatingProfile.tsx
@@ -169,6 +169,8 @@ const DesktopProfileFlyout = (props: {
   const { isMobileWidth } = useWindowProperties();
   const [customStatus, setCustomStatus] = createSignal("");
 
+  const navigate = useNavigate();
+
   const isMobileWidthMemo = createMemo(() => isMobileWidth());
   createEffect(
     on(
@@ -373,7 +375,21 @@ const DesktopProfileFlyout = (props: {
           animate={!props.dmPane ? true : hover()}
           hexColor={user()?.hexColor}
           url={bannerUrl(user()!)}
-        />
+        >
+          <Show when={isMe() && !props.showProfileSettings}>
+            <Button
+              padding={4}
+              textSize={12}
+              iconSize={18}
+              onClick={() => navigate("/app/settings/account")}
+              color={colors().primary}
+              label={t("profile.personal.editProfile")}
+              class={styles.bannerButton}
+              iconName="edit"
+              margin={0}
+            />
+          </Show>
+        </Banner>
         <div class={styles.flyoutDetailsContainer}>
           <CustomLink
             href={RouterEndpoints.PROFILE(props.userId)}


### PR DESCRIPTION
# Pull Request Template

## What does this PR do?
Adds an edit profile button on the user's floating profile banner

## Screenshots
<img width="388" height="217" alt="image" src="https://github.com/user-attachments/assets/d611cbdb-bb97-44d8-bca8-a7b81da74025" />

https://github.com/user-attachments/assets/c2afd897-7927-477e-8017-1cfde28504d6

## Did you test your code?
Tested on all Screen-sizes

## Additional context
none

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an "Edit Profile" button to the floating profile banner for users viewing their own profile. The button provides quick access to account settings with a label that reveals on hover for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->