### PR TITLE
chore: refactor font styles to use classes

### DIFF
--- a/src/common/fonts.ts
+++ b/src/common/fonts.ts
@@ -1,6 +1,7 @@
 export interface Font {
   id: number;
   name: string;
+  class: string;
   import: () => Promise<{ default: typeof import("*.css") }>;
   scale: number;
   lineHeight?: number;
@@ -10,6 +11,7 @@ export const Fonts: Font[] = [
   {
     id: 0,
     name: "Inter",
+    class: "font-inter",
     import: () => import("@fontsource/inter/latin-400.css"),
     scale: 1,
     lineHeight: 1.2,
@@ -17,12 +19,14 @@ export const Fonts: Font[] = [
   {
     id: 1,
     name: "Pixelify Sans",
+    class: "font-pixelify-sans",
     import: () => import("@fontsource/pixelify-sans/latin-400.css"),
     scale: 1,
   },
   {
     id: 2,
     name: "Indie Flower",
+    class: "font-indie-flower",
     import: () => import("@fontsource/indie-flower/latin-400.css"),
     scale: 1.33,
     lineHeight: 0.9,
@@ -30,40 +34,61 @@ export const Fonts: Font[] = [
   {
     id: 3,
     name: "IBM Plex Mono",
+    class: "font-ibm-plex-mono",
     import: () => import("@fontsource/ibm-plex-mono/latin-400.css"),
     scale: 0.9,
   },
   {
     id: 4,
     name: "Dancing Script",
+    class: "font-dancing-script",
     import: () => import("@fontsource/dancing-script/latin-400.css"),
     scale: 1,
   },
   {
     id: 5,
     name: "Mochiy Pop One",
+    class: "font-mochiy-pop-one",
     import: () => import("@fontsource/mochiy-pop-one/latin-400.css"),
     scale: 0.8,
   },
   {
     id: 6,
     name: "Grandstander",
+    class: "font-grandstander",
     import: () => import("@fontsource/grandstander/latin-400.css"),
     scale: 1.2,
   },
   {
     id: 7,
     name: "Sora",
+    class: "font-sora",
     import: () => import("@fontsource/sora/latin-400.css"),
     scale: 0.9,
   },
   {
     id: 8,
     name: "Roboto Slab",
+    class: "font-roboto-slab",
     import: () => import("@fontsource/roboto-slab/latin-400.css"),
     scale: 0.9,
   },
 ];
+
+const generateStylesheet = () => {
+  const el = document.createElement("style");
+  el.textContent = Fonts.map((f) => {
+    return `.${f.class} {
+      --font: '${f.name}';
+      --lh: ${f.lineHeight ?? "initial"};
+      --scale: ${f.scale ?? "initial"};
+      --ls: ${f.letterSpacing ?? "initial"};
+    }`;
+  }).join("\n");
+  return el;
+};
+
+document.head.appendChild(generateStylesheet());
 
 export const getFont = (id: number) =>
   Fonts.find((f) => f.id === id) || Fonts[0];

--- a/src/components/floating-profile/FloatingProfile.tsx
+++ b/src/components/floating-profile/FloatingProfile.tsx
@@ -400,14 +400,8 @@ const DesktopProfileFlyout = (props: {
                 href={RouterEndpoints.PROFILE(props.userId)}
               >
                 <Text
-                  style={{
-                    "overflow-wrap": "anywhere",
-                    "--font": `'${font()?.name}'`,
-                    "--lh": font()?.lineHeight,
-                    "--scale": font()?.scale,
-                    "--ls": font()?.letterSpacing
-                  }}
-                  class={styles.username}
+                  style={{ "overflow-wrap": "anywhere" }}
+                  class={cn(styles.username, font()?.class)}
                 >
                   {user()!.username}
                 </Text>

--- a/src/components/home-drawer/friend-item/HomeDrawerFriendItem.tsx
+++ b/src/components/home-drawer/friend-item/HomeDrawerFriendItem.tsx
@@ -1,5 +1,5 @@
 import styles from "./styles.module.scss";
-import { classNames, conditionalClass } from "@/common/classNames";
+import { cn } from "@/common/classNames";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import { A, useNavigate, useParams } from "solid-navigator";
@@ -19,7 +19,7 @@ import { formatTimestamp } from "@/common/date";
 import { unblockUser } from "@/chat-api/services/UserService";
 import { Modal } from "@/components/ui/modal";
 import { Item } from "@/components/ui/Item";
-import { Fonts, getFont } from "@/common/fonts";
+import { getFont } from "@/common/fonts";
 
 export default function HomeDrawerFriendItem(props: {
   friend?: Friend;
@@ -106,15 +106,7 @@ export default function HomeDrawerFriendItem(props: {
           <Avatar animate={hovered()} user={user()} size={28} />
         </A>
         <div class={styles.details}>
-          <div
-            class={styles.username}
-            style={{
-              "--font": `'${font()?.name}'`,
-              "--lh": font()?.lineHeight,
-              "--ls": font()?.letterSpacing,
-              "--scale": font()?.scale,
-            }}
-          >
+          <div class={cn(styles.username, font()?.class)}>
             {user().username}
           </div>
           <Show when={isBlocked()}>

--- a/src/components/message-pane/message-item/MessageItem.tsx
+++ b/src/components/message-pane/message-item/MessageItem.tsx
@@ -262,7 +262,11 @@ const Details = (props: DetailsProps) => {
           userDetailsPreloader.preload(props.message.createdBy.id);
         }}
         onContextMenu={props.userContextMenu}
-        class={classNames("trigger-profile-flyout", styles.username)}
+        class={classNames(
+          "trigger-profile-flyout",
+          styles.username,
+          font()?.class,
+        )}
         href={
           props.message.webhookId
             ? "#"
@@ -271,11 +275,7 @@ const Details = (props: DetailsProps) => {
         style={{
           "--gradient":
             topRoleWithColor()?.gradient || topRoleWithColor()?.hexColor,
-          "--color": topRoleWithColor()?.hexColor!,
-          "--font": `'${font()?.name}'`,
-          "--lh": font()?.lineHeight,
-          "--ls": font()?.letterSpacing,
-          "--scale": font()?.scale
+          "--color": topRoleWithColor()?.hexColor!
         }}
       >
         {props.serverMember?.nickname || props.message.createdBy.username}

--- a/src/components/post-area/PostItem.tsx
+++ b/src/components/post-area/PostItem.tsx
@@ -48,7 +48,7 @@ import MemberContextMenu from "../member-context-menu/MemberContextMenu";
 import { fetchTranslation, TranslateRes } from "@/common/GoogleTranslate";
 import { toast } from "../ui/custom-portal/CustomPortal";
 import { CreateTicketModal } from "@/components/CreateTicketModal";
-import { Fonts, getFont } from "@/common/fonts";
+import { getFont } from "@/common/fonts";
 import { Trans } from "@nerimity/solid-i18lite";
 
 const viewsEnabledAt = new Date();
@@ -261,14 +261,8 @@ const Details = (props: {
     <div class={cn(style.postDetailsContainer, "postDetailsContainer")}>
       <CustomLink
         onContextMenu={props.onRequestUserContextMenu}
-        class={style.postUsernameStyle}
-        style={{
-          color: "white",
-          "--font": `'${font()?.name}'`,
-          "--lh": font()?.lineHeight,
-          "--ls": font()?.letterSpacing,
-          "--scale": font()?.scale,
-        }}
+        class={cn(style.postUsernameStyle, font()?.class)}
+        style={{ color: "white" }}
         onClick={(e) => e.stopPropagation()}
         decoration
         href={RouterEndpoints.PROFILE(props.post.createdBy?.id)}

--- a/src/components/profile-pane/ProfilePane.tsx
+++ b/src/components/profile-pane/ProfilePane.tsx
@@ -79,7 +79,7 @@ import {
 } from "@/common/themes";
 import DeleteConfirmModal from "../ui/delete-confirm-modal/DeleteConfirmModal";
 import { getActivityType } from "@/common/activityType";
-import { Fonts, getFont } from "@/common/fonts";
+import { getFont } from "@/common/fonts";
 import { Modal } from "../ui/modal";
 
 const ActionButtonsContainer = styled(FlexRow)`
@@ -277,15 +277,7 @@ export default function ProfilePane() {
                   <div class={styles.details}>
                     <div class={styles.usernameTagOuter}>
                       <div class={styles.usernameTag}>
-                        <span
-                          class={styles.username}
-                          style={{
-                            "--font": `'${font()?.name}'`,
-                            "--lh": font()?.lineHeight,
-                            "--ls": font()?.letterSpacing,
-                            "--scale": font()?.scale
-                          }}
-                        >
+                        <span class={cn(styles.username, font()?.class)}>
                           {user()!.username}
                         </span>
                         <span class={styles.tag}>{`:${user()!.tag}`}</span>

--- a/src/components/right-drawer/RightDrawer.tsx
+++ b/src/components/right-drawer/RightDrawer.tsx
@@ -149,15 +149,11 @@ const MemberItem = (props: {
         />
         <div class={styles.memberInfo}>
           <div
-            class={styles.username}
+            class={cn(styles.username, font()?.class)}
             style={{
               "--gradient":
                 topRoleWithColor()?.gradient || topRoleWithColor()?.hexColor,
-              "--color": topRoleWithColor()?.hexColor!,
-              "--font": `'${font()?.name}'`,
-              "--lh": font()?.lineHeight,
-              "--ls": font()?.letterSpacing,
-              "--scale": font()?.scale
+              "--color": topRoleWithColor()?.hexColor!
             }}
           >
             {props.member.nickname || user().username}


### PR DESCRIPTION
I don't know if this is the best way to go about it, but it works and reduces the code duplication.  Making a CSS file be the source of truth might be better, but it's unclear if lazy loading the fonts would work and that would require changing the font preview logic.  (which is currently unchanged by this PR.)

## Screenshots
No visible changes.

## Did you test your code?
Yes, on Firefox & Chrome on Linux.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] Text/content changes support internationalization (i18n)  
- [ ] Any new user-facing strings are properly localized
