### PR TITLE
fix: make swiping to open sidebar usable on firefox on mobile

### DIFF
--- a/src/common/useWindowProperties.ts
+++ b/src/common/useWindowProperties.ts
@@ -85,6 +85,7 @@ export function useWindowProperties() {
     },
     isMobileAgent: () => isMobileAgent,
     isSafari,
+    isFirefox,
     paneBackgroundColor,
     setPaneBackgroundColor
   };

--- a/src/components/ui/drawer/Drawer.tsx
+++ b/src/components/ui/drawer/Drawer.tsx
@@ -68,7 +68,7 @@ export default function DrawerLayout(props: DrawerLayoutProps) {
   let startTime = 0;
   let pauseTouches = false;
 
-  const { width, isMobileWidth, isSafari } = useWindowProperties();
+  const { width, isMobileWidth, isSafari, isFirefox } = useWindowProperties();
   const LeftDrawer = children(() => props.LeftDrawer());
   const RightDrawer = children(() => props.RightDrawer());
 
@@ -294,7 +294,7 @@ export default function DrawerLayout(props: DrawerLayoutProps) {
     updatePage();
   };
   const onScroll = () => {
-    if (isSafari) return;
+    if (isSafari || isFirefox) return;
     pauseTouches = true;
     updatePage();
   };


### PR DESCRIPTION
We disussed this in the dev chat a while back, but I guess we never pushed the patch...  This just enables the existing workaround used for Safari on Firefox as well.
(Arguably it's Chrome's behavior that's wrong here, but it's the behavior that works, so whatever.)

Fixes #514.

## Did you test your code?
Tested on Firefox on mobile (and Chrome on mobile, where it intentionally has no effect.)

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized
