### PR TITLE
fix: hide translation option on messages with no content

### DIFF
--- a/src/components/message-pane/message-log-area/MessageLogArea.tsx
+++ b/src/components/message-pane/message-log-area/MessageLogArea.tsx
@@ -1030,11 +1030,15 @@ function MessageContextMenu(props: MessageContextMenuProps) {
             ]
           : []),
 
-        {
-          icon: "translate",
-          label: t("messageContextMenu.translateMessage"),
-          onClick: onTranslateClick
-        },
+        ...(hasContent()
+          ? [
+              {
+                icon: "translate",
+                label: t("messageContextMenu.translateMessage"),
+                onClick: onTranslateClick
+              }
+            ]
+          : []),
         {
           icon: "mark_chat_unread",
           label: t("messageContextMenu.markUnread"),


### PR DESCRIPTION
This hides the translation option on messages with no content.  (Currently clicking translate on those messages silently does nothing.)
This applies to the following:
- System messages (should already be localized)
- Image-only messages
- HTML-embed only messages
    - if we add best-effort translation of HTML embeds in the future, it will also need to update the context menu.

## Screenshots

<img height="348" alt="image" src="https://github.com/user-attachments/assets/5dd628c9-6d30-4cc5-a4bb-bd7ad5986375" />
<img height="245" alt="image" src="https://github.com/user-attachments/assets/84b19a2d-2f89-48a5-bfb1-1b264e474c05" />
<img height="380" alt="image" src="https://github.com/user-attachments/assets/6a511067-58ff-46d7-b5b2-c54a45349702" />

## Did you test your code?
Tested on Firefox on Linux & Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The translate option in message context menus now only appears when messages contain content, improving menu relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->