### PR TITLE
feat: add remove button to floating attachment preview

### DIFF
--- a/src/components/message-pane/MessagePane.tsx
+++ b/src/components/message-pane/MessagePane.tsx
@@ -550,7 +550,7 @@ function MessageArea(props: {
         </Show>
         <FloatingSuggestions textArea={textAreaEl()} />
         <Show when={channelProperty()?.attachment}>
-          <FloatingAttachment />
+          <FloatingAttachment textArea={textAreaEl()} />
         </Show>
         <Show when={editMessageId()}>
           <EditIndicator messageId={editMessageId()!} />
@@ -1306,7 +1306,9 @@ function EditIndicator(props: { messageId: string }) {
   );
 }
 
-function FloatingAttachment(props: {}) {
+function FloatingAttachment(props: {
+  textArea?: HTMLElement,
+}) {
   const params = useParams<{ channelId: string }>();
   const { createPortal } = useCustomPortal();
   const { channelProperties } = useStore();
@@ -1349,6 +1351,11 @@ function FloatingAttachment(props: {}) {
   };
 
   const isMobileWidth = () => (paneWidth() || 0) <= 400;
+
+  const cancelAttachment = () => {
+    channelProperties.setAttachment(params.channelId, undefined);
+    props.textArea?.focus();
+  };
 
   return (
     <Floating
@@ -1395,6 +1402,16 @@ function FloatingAttachment(props: {}) {
             }
             items={uploadToOptions()}
             selectedId={getAttachmentFile()?.uploadTo}
+          />
+        </div>
+        <div class={styles.attachmentClose}>
+          <Button
+            iconName="close"
+            margin={0}
+            padding={0}
+            iconSize={24}
+            color="var(--alert-color)"
+            onClick={cancelAttachment}
           />
         </div>
       </div>

--- a/src/components/message-pane/styles.module.scss
+++ b/src/components/message-pane/styles.module.scss
@@ -356,6 +356,10 @@ body .floating.floatingSlowModeIndicator {
           padding: 6px;
         }
       }
+      .attachmentClose {
+        align-self: flex-start;
+        margin-left: auto;
+      }
     }
 
     .attachmentFilename {


### PR DESCRIPTION
This adds a button to the floating attachment preview to remove the attachment, to make it consistent with replies.  The existing add attachment button turns into a close/remove button after being clicked, but that isn't the first place someone would look when trying to remove the attachment.

The button doesn't end up in a great place on mobile; if you can think of a better place for it or an alternate design, that would be helpful.  (The general expectation is that close buttons are in the top right/top left corner, depending on OS; modal close buttons are usually in the bottom right or bottom left, so we might be able to style it that way?)

## Screenshots
<img height="227" alt="image" src="https://github.com/user-attachments/assets/9109e827-9ac2-407e-9b9c-b229e0b37bc4" />
<img height="450" alt="image" src="https://github.com/user-attachments/assets/40dd9e59-2b8d-49bd-aa01-1abd9fbfb890" />

## Did you test your code?
Tested on Firefox on desktop and Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)
