### PR TITLE
Round inputs & return "error" instead of throwing in time formatting functions

### DIFF
--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1350,6 +1350,7 @@
     "relativePast": "{{duration}} ago",
     "relativeNow": "now",
     "yesterdayTime": "Yesterday at {{time}}",
-    "dateTime": "{{date}} at {{time}}"
+    "dateTime": "{{date}} at {{time}}",
+    "error": "error"
   }
 }


### PR DESCRIPTION
This adds some fallback error handling to prevent the time formatting functions from throwing when receiving invalid input (NaN / Inf).  Most of the diff is indentation changes; the first commit adds rounding, the second adds the try/catch blocks.

## Did you test your code?
Tested on Firefox on desktop.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of date and time operations with enhanced error handling to prevent crashes and display localized error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->