### PR TITLE
fix: don't overwrite history with 404 page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -402,16 +402,12 @@ render(() => {
         <Route path="/reset-password" component={ResetPasswordPage} />
 
         <Route path="/404" component={NotFound} />
-        <Route path="/*" component={AllOther} />
+        <Route path="/*" component={NotFound} />
       </Router>
     </MetaProvider>
   );
 }, document.getElementById("root") as HTMLElement);
 
-function AllOther() {
-  location.href = "/404";
-  return <></>;
-}
 function NotFound() {
   return (
     <div>


### PR DESCRIPTION
This makes unknown routes return the 404 page directly, rather than overwriting the current history entry with `/404`.  This is partially for convenience when working with DEV-only pages (#576), but it's also better behavior overall -- the 404 handler shouldn't overwrite the url, since it makes figuring out why it failed harder.

## Did you test your code?
Tested on Firefox on desktop and Chrome on android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] Text/content changes support internationalization (i18n)  
- [ ] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route handling for unmatched URLs to provide a more direct and efficient error page display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->