### PR TITLE
Localize timezones

### DIFF
--- a/src/components/markup/TimestampMention.tsx
+++ b/src/components/markup/TimestampMention.tsx
@@ -1,4 +1,5 @@
-import { formatTimestamp, formatTimestampRelative } from "@/common/date";
+import { formatters as dateFormatters, formatTimestamp, formatTimestampRelative } from "@/common/date";
+import { Temporal } from "temporal-polyfill";
 import {
   createEffect,
   createMemo,
@@ -14,7 +15,6 @@ import { Modal } from "../ui/modal";
 import { addReminder } from "@/chat-api/services/ReminderService";
 import { Message } from "@/chat-api/store/useMessages";
 import Text from "../ui/Text";
-import { WorldTimezones } from "@/common/WorldTimezones";
 import { t } from "@nerimity/i18lite";
 
 export enum TimestampType {
@@ -31,38 +31,24 @@ export function TimestampMention(props: {
   const { createPortal } = useCustomPortal();
   const [formattedTime, setFormattedTime] = createSignal("...");
 
-  const isValidTimezone = createMemo(() => {
-    return WorldTimezones.includes(props.timestamp as unknown as string);
-  });
-
   const updateTime = () => {
     if (props.type === TimestampType.RELATIVE) {
       return setFormattedTime(formatTimestampRelative(props.timestamp));
     }
     if (props.type === TimestampType.OFFSET) {
       const offset = props.timestamp as unknown as string;
-
-      if (isValidTimezone()) {
-        const date = new Date().toLocaleString("en-GB", { timeZone: offset });
-        return setFormattedTime(date.split(",")[1]?.trim() || "...");
+      try {
+        const datetime = Temporal.Now.zonedDateTimeISO(offset)
+          .round({
+            smallestUnit: "second",
+            roundingMode: "floor",
+          });
+        const formatted = dateFormatters().datetime.seconds
+          .format(datetime.toPlainTime());
+        return setFormattedTime(formatted);
+      } catch {
+        return setFormattedTime(t("datetime.invalidTimezone"));
       }
-      const offsetSign = offset[0] as "+" | "-";
-      const offsetHours = Number(offsetSign + offset.slice(1, 3));
-      const offsetMinutes = Number(offsetSign + offset.slice(3, 6));
-
-      const date = new Date();
-      const utcDate = new Date(
-        date.getUTCFullYear(),
-        date.getUTCMonth(),
-        date.getUTCDate(),
-        date.getUTCHours(),
-        date.getUTCMinutes(),
-        date.getUTCSeconds()
-      );
-
-      utcDate.setMinutes(utcDate.getMinutes() + offsetMinutes);
-      utcDate.setHours(utcDate.getHours() + offsetHours);
-      setFormattedTime(formatTimestamp(utcDate.getTime(), true));
     }
   };
 

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -1351,6 +1351,7 @@
     "relativeNow": "now",
     "yesterdayTime": "Yesterday at {{time}}",
     "dateTime": "{{date}} at {{time}}",
-    "error": "error"
+    "error": "error",
+    "invalidTimezone": "invalid time zone"
   }
 }


### PR DESCRIPTION
This uses the Temporal API to localize the timezone mention formatting.  The current formatting behaves differently for named timezones, positive offsets, and negative offsets; most don't follow the configured language / 24h preferences.  This version follows the localized format in all cases, and displays invalid time zones (out of range offsets, or time zone names that are unsupported on the local system) as a translatable error message.

## Screenshots
For these timezones, displayed with the en-US language and 12 hour time selected:
```
[to:America/Los_Angeles]
[to:America/Louisville]
[to:Europe/London]
[to:+0800]
[to:+0000]
[to:+9999]
[to:+2300]
[to:+2400]
[to:+2359]
[to:-2400]
```

Current:
<img height="378" alt="image" src="https://github.com/user-attachments/assets/7504ad46-5f37-4ed3-a1dc-7b4c44d398c8" />
With this PR:
<img height="379" alt="image" src="https://github.com/user-attachments/assets/767c4426-1754-4c8d-aa2f-1bfd6264a7b6" />

## Did you test your code?
Tested on Firefox on Linux and Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced timestamp offset calculations for improved accuracy and reliability

* **Bug Fixes**
  * Added proper error handling and localized messaging for invalid timezone inputs

* **Localization**
  * Expanded English (GB) locale support with timezone error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->