### PR TITLE
fix: don't show blocked users as friends in quick travel modal

### DIFF
--- a/src/components/QuickTravel/QuickTravelController.tsx
+++ b/src/components/QuickTravel/QuickTravelController.tsx
@@ -1,4 +1,4 @@
-import { ChannelType } from "@/chat-api/RawData";
+import { ChannelType, FriendStatus } from "@/chat-api/RawData";
 import useStore from "@/chat-api/store/useStore";
 import { createContextProvider } from "@solid-primitives/context";
 import {
@@ -50,7 +50,8 @@ const [QuickTravelControllerProvider, useQuickTravelController] =
       const users = store.users.array();
 
       return users.map((user) => {
-        const friend = store.friends.get(user.id);
+        const friend =
+          store.friends.get(user.id)?.status === FriendStatus.FRIENDS;
         const inbox = user.inboxChannelId
           ? store.inbox.get(user.inboxChannelId)
           : undefined;
@@ -127,8 +128,12 @@ const [QuickTravelControllerProvider, useQuickTravelController] =
             const inboxA = "inbox" in a && !!a.inbox;
             const inboxB = "inbox" in b && !!b.inbox;
 
-            const friendA = "id" in a && !!store.friends.get(a.id!);
-            const friendB = "id" in b && !!store.friends.get(b.id!);
+            const friendA =
+              "id" in a &&
+              store.friends.get(a.id!)?.status === FriendStatus.FRIENDS;
+            const friendB =
+              "id" in b &&
+              store.friends.get(b.id!)?.status === FriendStatus.FRIENDS;
 
             if (inboxA && !inboxB) return -1;
             if (!inboxA && inboxB) return 1;


### PR DESCRIPTION
This fixes a bug where blocked users were treated as friends in the quick travel modal listing.

## Did you test your code?
Tested on Firefox on desktop and Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] Text/content changes support internationalization (i18n)  
- [ ] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved friendship status detection in search results. Users are now correctly identified as friends and sorted appropriately. User items are properly categorized between friends, inbox contacts, and regular users based on explicit status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->