### PR TITLE
chore: simplify time formatting logic in explore

### DIFF
--- a/src/components/explore/ExploreBots.tsx
+++ b/src/components/explore/ExploreBots.tsx
@@ -15,7 +15,7 @@ import Icon from "../ui/icon/Icon";
 import { Notice } from "../ui/Notice/Notice";
 import Text from "../ui/Text";
 import { Banner } from "../ui/Banner";
-import { getDaysAgo, timeSince } from "@/common/date";
+import { timeSince } from "@/common/date";
 import { toast, useCustomPortal } from "../ui/custom-portal/CustomPortal";
 import { Skeleton } from "../ui/skeleton/Skeleton";
 import { classNames, cn } from "@/common/classNames";
@@ -352,12 +352,6 @@ function PublicItem(props: {
     ));
   };
 
-  const bumpedUnder24Hours = () => {
-    const millisecondsSinceLastBump =
-      new Date().getTime() - props.item.bumpedAt;
-    return millisecondsSinceLastBump < 24 * 60 * 60 * 1000;
-  };
-
   return (
     <ServerItemContainer
       class={classNames(
@@ -434,9 +428,7 @@ function PublicItem(props: {
           <Icon name="schedule" size={17} color="var(--primary-color)" />
           <Text size={14}>
             {t("explore.bumped")}{" "}
-            {(bumpedUnder24Hours() ? timeSince : getDaysAgo)(
-              props.item.bumpedAt
-            )}
+            {timeSince(props.item.bumpedAt, false)}
           </Text>
         </FlexRow>
       </MemberContainer>

--- a/src/components/explore/ExploreServers.tsx
+++ b/src/components/explore/ExploreServers.tsx
@@ -17,7 +17,7 @@ import Icon from "../ui/icon/Icon";
 import { Notice } from "../ui/Notice/Notice";
 import Text from "../ui/Text";
 import { Banner } from "../ui/Banner";
-import { getDaysAgo, timeSince } from "@/common/date";
+import { timeSince } from "@/common/date";
 import { toast, useCustomPortal } from "../ui/custom-portal/CustomPortal";
 import LegacyModal from "../ui/legacy-modal/LegacyModal";
 import { Turnstile, TurnstileRef } from "@nerimity/solid-turnstile";
@@ -411,12 +411,6 @@ function PublicServerItem(props: {
     ));
   };
 
-  const bumpedUnder24Hours = () => {
-    const millisecondsSinceLastBump =
-      new Date().getTime() - props.publicServer.bumpedAt;
-    return millisecondsSinceLastBump < 24 * 60 * 60 * 1000;
-  };
-
   return (
     <ServerItemContainer
       class={classNames(
@@ -497,9 +491,7 @@ function PublicServerItem(props: {
           <Icon name="schedule" size={17} color="var(--primary-color)" />
           <Text size={14}>
             {t("explore.bumped")}{" "}
-            {(bumpedUnder24Hours() ? timeSince : getDaysAgo)(
-              props.publicServer.bumpedAt,
-            )}
+            {timeSince(props.publicServer.bumpedAt, false)}
           </Text>
         </FlexRow>
       </MemberContainer>


### PR DESCRIPTION
This simplifies the time formatting logic for bumps in Explore by using the option to `timeSince` to use a duration in days instead of falling back to a full timestamp.

## Did you test your code?
Tested on Firefox on desktop & chrome on Android; no visible changes.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized
