### PR TITLE
chore: rename Button 'styles' prop to 'style' for consistency

### DIFF
--- a/src/components/InviteBotPopup.tsx
+++ b/src/components/InviteBotPopup.tsx
@@ -122,7 +122,7 @@ export const InviteBotPopup = (props: {
           iconName="add"
           primary
           margin={0}
-          styles={{ "align-self": "stretch" }}
+          style={{ "align-self": "stretch" }}
           onClick={addBot}
         />
       </FlexColumn>

--- a/src/components/message-pane/MessagePane.tsx
+++ b/src/components/message-pane/MessagePane.tsx
@@ -931,7 +931,7 @@ const MicButton = (props: { onBlob?: (blob: Blob) => void }) => {
       </Show>
       <Button
         type="hover_border"
-        styles={{ "touch-action": "none", "user-select": "none" }}
+        style={{ "touch-action": "none", "user-select": "none" }}
         class={classNames(styles.inputButtons, "voice-recorder-button")}
         onPointerDown={onMicHold}
         onTouchMove={onTouchMove}
@@ -1375,7 +1375,7 @@ function FloatingAttachment(props: {}) {
               padding={6}
               iconSize={18}
               primary
-              styles={{ "margin-left": "auto" }}
+              style={{ "margin-left": "auto" }}
               iconName="brush"
             />
           </div>
@@ -2324,14 +2324,14 @@ const GoogleDriveLinkModal = (props: { close: () => void }) => {
   const actionButtons = (
     <FlexRow style={{ width: "100%" }}>
       <Button
-        styles={{ flex: 1 }}
+        style={{ flex: 1 }}
         iconName="close"
         label={t("messageArea.linkToGoogleDrive.cancelButton")}
         color="var(--alert-color)"
         onClick={props.close}
       />
       <Button
-        styles={{ flex: 1 }}
+        style={{ flex: 1 }}
         label={t("messageArea.linkToGoogleDrive.linkButton")}
         iconName="link"
         primary
@@ -2441,7 +2441,7 @@ function BeforeYouChatNotice(props: {
             <Markup inline text={notice()!.content} />
           </div>
           <Button
-            styles={{ opacity: buttonClickable() ? 1 : 0.5 }}
+            style={{ opacity: buttonClickable() ? 1 : 0.5 }}
             label={t("settings.account.understoodButton")}
             iconName="check"
             onClick={understoodClick}

--- a/src/components/message-pane/message-item/AudioEmbed.tsx
+++ b/src/components/message-pane/message-item/AudioEmbed.tsx
@@ -178,7 +178,7 @@ export const AudioEmbed = (props: {
             onClick={onPlayClick}
             iconName={statusIcon()}
             color="var(--primary-color)"
-            styles={{ "border-radius": "50%" }}
+            style={{ "border-radius": "50%" }}
           />
           <div class={styles.fileEmbedDetails}>
             <div class={styles.fileEmbedName}>{props.file?.name}</div>

--- a/src/components/message-pane/message-item/Reactions.tsx
+++ b/src/components/message-pane/message-item/Reactions.tsx
@@ -142,7 +142,7 @@ function AddNewReactionButton(props: {
       margin={0}
       padding={6}
       class={style.reactionItem}
-      styles={{ visibility: show() ? "visible" : "hidden" }}
+      style={{ visibility: show() ? "visible" : "hidden" }}
       iconName="add"
       iconSize={15}
     />

--- a/src/components/moderation-pane/ModerationPane.tsx
+++ b/src/components/moderation-pane/ModerationPane.tsx
@@ -1372,7 +1372,7 @@ function AuditLogItem(props: { auditLog: AuditLog }) {
         <Button
           padding={4}
           margin={[0, 6, 0, 0]}
-          styles={{ "margin-left": "auto", "align-self": "start" }}
+          style={{ "margin-left": "auto", "align-self": "start" }}
           iconName="arrow_drop_down"
           onClick={() => setExpanded(!expanded())}
         />

--- a/src/components/servers/settings/ExternalEmbedSettings.tsx
+++ b/src/components/servers/settings/ExternalEmbedSettings.tsx
@@ -135,7 +135,7 @@ export default function ExternalEmbedSettings() {
           children={
             <Button
               label={t("servers.settings.externalEmbed.noInvites.createButton")}
-              styles={{ "margin-left": "auto" }}
+              style={{ "margin-left": "auto" }}
               margin={0}
               primary
               onclick={() =>

--- a/src/components/servers/settings/ServerVerifySettings.tsx
+++ b/src/components/servers/settings/ServerVerifySettings.tsx
@@ -82,7 +82,7 @@ export default function ServerSettingsBans() {
               <Button
                 onClick={verifyClick}
                 label={t("servers.settings.verify.verifyButton")}
-                styles={{ "margin-left": "auto" }}
+                style={{ "margin-left": "auto" }}
                 margin={0}
                 color="var(--success-color)"
               />

--- a/src/components/settings/AccountSettings.tsx
+++ b/src/components/settings/AccountSettings.tsx
@@ -665,7 +665,7 @@ function DeleteAccountNoticeModal(props: { close(): void }) {
       actionButtons={
         <Button
           iconName="check"
-          styles={{ "margin-left": "auto" }}
+          style={{ "margin-left": "auto" }}
           label={t("settings.account.understoodButton")}
           onClick={props.close}
         />
@@ -897,13 +897,13 @@ const ConfirmEmailModal = (props: { close(): void; message: string }) => {
     <FlexRow style={{ flex: 1 }}>
       <Button
         onClick={props.close}
-        styles={{ flex: 1 }}
+        style={{ flex: 1 }}
         iconName="close"
         label={t("general.cancelButton")}
         color="var(--alert-color)"
       />
       <Button
-        styles={{ flex: 1 }}
+        style={{ flex: 1 }}
         iconName="check"
         label={t("general.confirmButton")}
         onClick={confirmClicked}
@@ -957,13 +957,13 @@ const ConfirmPasswordModal = (props: {
     <FlexRow style={{ flex: 1 }}>
       <Button
         onClick={props.close}
-        styles={{ flex: 1 }}
+        style={{ flex: 1 }}
         iconName="close"
         label={t("general.cancelButton")}
         color="var(--alert-color)"
       />
       <Button
-        styles={{ flex: 1 }}
+        style={{ flex: 1 }}
         iconName="check"
         label={t("general.confirmButton")}
         onClick={() => props.onConfirm(password())}

--- a/src/components/settings/NotificationsSettings.tsx
+++ b/src/components/settings/NotificationsSettings.tsx
@@ -234,7 +234,7 @@ function NotificationSoundDropDown(props: {
             <div style={{ "margin-left": "auto", "flex-shrink": 0 }}>
               <Button
                 onClick={(e) => testSound(e, sound)}
-                styles={{ "margin-left": "6px", "flex-shrink": 0 }}
+                style={{ "margin-left": "6px", "flex-shrink": 0 }}
                 iconName="play_circle"
                 margin={0}
                 padding={4}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -8,7 +8,7 @@ import { A } from "solid-navigator";
 
 export type ButtonProps = Omit<
   JSX.ButtonHTMLAttributes<HTMLButtonElement>,
-  "color" | "type"
+  "color" | "type" | "style"
 > & {
   color?: string | null;
   label?: string;
@@ -23,7 +23,7 @@ export type ButtonProps = Omit<
   href?: string;
   target?: string;
   rel?: string;
-  styles?: JSX.CSSProperties;
+  style?: JSX.CSSProperties;
   tabIndex?: string;
   hoverText?: string;
   iconClass?: string;
@@ -44,7 +44,7 @@ export default function Button(props: ButtonProps) {
     "customChildren",
     "href",
     "customChildrenLeft",
-    "styles",
+    "style",
     "tabIndex",
     "hoverText",
     "iconClass",
@@ -70,7 +70,7 @@ export default function Button(props: ButtonProps) {
           ? props.padding.join("px ") + "px"
           : props.padding + "px"
         : undefined,
-    ...customProps.styles,
+    ...customProps.style,
   });
 
   return (

--- a/src/components/ui/ImageCropModal.tsx
+++ b/src/components/ui/ImageCropModal.tsx
@@ -108,7 +108,7 @@ export default function ImageCropModal(props: {
           iconName="check"
           label={t("general.doneButton")}
           onClick={onClick}
-          styles={{ flex: 1 }}
+          style={{ flex: 1 }}
           primary
           padding={10}
         />

--- a/src/components/ui/emoji-picker/EmojiPicker.tsx
+++ b/src/components/ui/emoji-picker/EmojiPicker.tsx
@@ -179,7 +179,7 @@ export function EmojiPicker(props: {
         <div class={styles.tabs}>
           <Show when={gifPickerSearch().trim()}>
             <Button
-              styles={{ "margin-right": "auto", "margin-left": "6px" }}
+              style={{ "margin-right": "auto", "margin-left": "6px" }}
               iconName="arrow_back"
               margin={0}
               onClick={() => setGifPickerSearch("")}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -119,7 +119,7 @@ export default function LoginPage() {
             </Show>
             <Button
               primary
-              styles={{ flex: 1 }}
+              style={{ flex: 1 }}
               margin={[10, 0, 0, 0]}
               iconName="login"
               label={

--- a/src/pages/OAuthAuthorizePage.tsx
+++ b/src/pages/OAuthAuthorizePage.tsx
@@ -212,7 +212,7 @@ export const OAuthAuthorizePopup = (props: {
           iconName="check"
           primary
           margin={[10, 0, 0, 0]}
-          styles={{ "align-self": "stretch" }}
+          style={{ "align-self": "stretch" }}
           onClick={authorizeClick}
         />
       </Show>

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -222,7 +222,7 @@ export default function RegisterPage() {
             </Text>
             <Button
               primary
-              styles={{ flex: 1 }}
+              style={{ flex: 1 }}
               margin={[10, 0, 0, 0]}
               iconName="login"
               label={

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -136,7 +136,7 @@ export default function ResetPasswordPage() {
                 </Text>
                 <Button
                   primary
-                  styles={{ flex: 1 }}
+                  style={{ flex: 1 }}
                   margin={[10, 0, 0, 0]}
                   iconName="key"
                   label={
@@ -204,7 +204,7 @@ const SendCodePage = () => {
             </Text>
             <Button
               primary
-              styles={{ flex: 1 }}
+              style={{ flex: 1 }}
               margin={[10, 0, 0, 0]}
               iconName="mail"
               label={


### PR DESCRIPTION
Button was the only component that used `styles` instead of `style`; it also silently ignored the normal `style` property inherited from `<button>`, which caused at least one bug -- the explore themes button in interface settings was styled, but those styles were ignored.

This is literally just using a LSP rename from `styles` to `style`, renaming `"styles"` to `"style"` in the `splitProps` list, and adding `"style"` to the `Omit` section of `ButtonProps`.  There are no remaining uses of `styles=` in the codebase, so I believe it got everything.

## Screenshots
The current preset theme list in interface settings; only the button is clickable in the explore pane.
<img height="300" alt="image" src="https://github.com/user-attachments/assets/554e31f3-5fdd-43a5-8a5d-375bf6a18543" />

With this PR; there are no new styles, just that the existing styles are correctly applied.  The entire pane is clickable.
<img height="300" alt="image" src="https://github.com/user-attachments/assets/15be8d25-4557-4c1c-ba1d-916285c45799" />

## Did you test your code?
Tested on Firefox on Linux and Chrome on Android.  

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized button component styling interface across the application by updating prop naming conventions for consistency. This internal refactor improves code maintainability with no impact on user-facing functionality or visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->