### PR TITLE
fix: use the same ThemeCard logic for explore and settings

### DIFF
--- a/src/components/explore/ExploreThemes.tsx
+++ b/src/components/explore/ExploreThemes.tsx
@@ -3,11 +3,12 @@ import { styled, css } from "solid-styled-components";
 import Button from "../ui/Button";
 import Input from "../ui/input/Input";
 import { t } from "@nerimity/i18lite";
-import { applyTheme, DefaultTheme, themePresets } from "@/common/themes";
+import { ThemePreset, themePresets } from "@/common/themes";
 import { Skeleton } from "../ui/skeleton/Skeleton";
-import { FlexColumn, FlexRow } from "../ui/Flexbox";
+import { FlexRow } from "../ui/Flexbox";
 import useStore from "@/chat-api/store/useStore";
 import { Notice } from "../ui/Notice/Notice";
+import ThemeCard from "./ThemeCard";
 
 const Container = styled("div")`
   display: flex;
@@ -29,31 +30,6 @@ const SectionTitle = styled("h3")`
   color: var(--text-color);
 `;
 
-const ThemeCardContainer = styled(FlexColumn)`
-  background: var(--pane-color);
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  padding: 12px;
-  gap: 8px;
-  transition: transform 0.2s, box-shadow 0.2s;
-  &:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
-  }
-`;
-
-const ColorPreview = styled(FlexRow)`
-  flex-wrap: wrap;
-  gap: 6px;
-`;
-
-const ColorBlock = styled("div")`
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-`;
-
 const GitHubButton = styled(Button)`
   display: flex;
   align-items: center;
@@ -66,40 +42,8 @@ const GitHubButton = styled(Button)`
   }
 `;
 
-type ThemeObject = {
-  colors?: Record<string, string>;
-  maintainers?: string[];
-};
-
-function ThemeCard(props: { name: string; themeObj: ThemeObject }) {
-  const colors = props.themeObj.colors || {};
-  const maintainers = props.themeObj.maintainers || [];
-  const bgColor = colors["pane-color"] || DefaultTheme["pane-color"];
-  const textColor = colors["text-color"] || DefaultTheme["text-color"];
-
-  return (
-    <ThemeCardContainer style={{ background: bgColor, color: textColor }}>
-      <strong>{props.name}</strong>
-      <Show when={maintainers.length}>
-        <div>
-          {t("settings.interface.maintainers")}: {maintainers.join(", ")}
-        </div>
-      </Show>
-      <ColorPreview>
-        <For each={Object.values({ ...DefaultTheme, ...colors })}>
-          {(color) => <ColorBlock style={{ "background-color": color }} />}
-        </For>
-      </ColorPreview>
-      <Button
-        label={t("settings.interface.apply")}
-        onClick={() => applyTheme(props.name, props.themeObj)}
-      />
-    </ThemeCardContainer>
-  );
-}
-
 export default function ExploreThemes() {
-  const [themes, setThemes] = createSignal<Record<string, ThemeObject>>({});
+  const [themes, setThemes] = createSignal<Record<string, ThemePreset>>({});
   const [loading, setLoading] = createSignal(true);
   const { header } = useStore();
   const [search, setSearch] = createSignal("");
@@ -178,19 +122,17 @@ export default function ExploreThemes() {
         />
       </FlexRow>
 
-      {}
       <Show when={officialThemes().length}>
         <SectionTitle>{t("explore.themes.officialThemes")}</SectionTitle>
         <GridLayout>
           <For each={officialThemes()}>
             {([name, themeObj]) => (
-              <ThemeCard name={name} themeObj={themeObj} />
+              <ThemeCard name={name} themeObj={themeObj} explore />
             )}
           </For>
         </GridLayout>
       </Show>
 
-      {}
       <SectionTitle>{t("explore.themes.communityThemes")}</SectionTitle>
       <GridLayout>
         <Show when={loading()}>
@@ -202,7 +144,7 @@ export default function ExploreThemes() {
         <Show when={!loading() && communityThemes().length > 0}>
           <For each={communityThemes()}>
             {([name, themeObj]) => (
-              <ThemeCard name={name} themeObj={themeObj} />
+              <ThemeCard name={name} themeObj={themeObj} explore />
             )}
           </For>
         </Show>

--- a/src/components/explore/ThemeCard.module.css
+++ b/src/components/explore/ThemeCard.module.css
@@ -1,0 +1,68 @@
+.themeCard {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border-radius: 10px;
+  font-size: 14px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  &:hover {
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+  }
+
+  .colorPreview {
+    display: flex;
+    flex-wrap: wrap;
+    padding-bottom: 8px;
+    gap: 4px;
+  }
+
+  .colorBlock {
+    width: 20px;
+    height: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+  }
+
+  .themeName {
+    margin-bottom: 4px;
+    text-transform: capitalize;
+    font-weight: bold;
+  }
+
+  .maintainers {
+    margin-bottom: 8px;
+    opacity: 0.7;
+    font-size: 12px;
+    font-style: italic;
+  }
+}
+
+.themeCard.explore {
+  font-size: 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+  background: var(--pane-color);
+
+  .colorPreview {
+    gap: 6px;
+  }
+  .maintainers {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 600px) {
+  .themeCard {
+    padding: 10px;
+
+    .colorBlock {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}

--- a/src/components/explore/ThemeCard.tsx
+++ b/src/components/explore/ThemeCard.tsx
@@ -1,0 +1,56 @@
+import { createMemo, For, Show } from "solid-js";
+import { cn, conditionalClass } from "@/common/classNames";
+import { t } from "@nerimity/i18lite";
+import Button from "../ui/Button";
+import { applyTheme, DefaultTheme, ThemePreset } from "@/common/themes";
+import style from "./ThemeCard.module.css";
+
+export default function ThemeCard(props: {
+  name: string;
+  themeObj: ThemePreset;
+  explore?: boolean;
+}) {
+  const theme = createMemo(() => {
+    const themeColors = props.themeObj.colors || {};
+    const colors = { ...DefaultTheme, ...themeColors };
+    return {
+      maintainers: props.themeObj.maintainers || [],
+      colors
+    };
+  });
+
+  return (
+    <div
+      class={cn(
+        style.themeCard,
+        conditionalClass(props.explore, style.explore)
+      )}
+      style={{
+        background: theme().colors["pane-color"],
+        color: theme().colors["text-color"]
+      }}
+    >
+      <div class={style.themeName}>{props.name}</div>
+      <Show when={theme().maintainers.length}>
+        <div class={style.maintainers}>
+          {t("settings.interface.maintainers")}:{" "}
+          {theme().maintainers.join(", ")}
+        </div>
+      </Show>
+      <div class={style.colorPreview}>
+        <For each={Object.values(theme().colors)}>
+          {(color) => (
+            <div
+              class={style.colorBlock}
+              style={{ "background-color": color }}
+            />
+          )}
+        </For>
+      </div>
+      <Button
+        label={t("settings.interface.apply")}
+        onClick={() => applyTheme(props.name, props.themeObj)}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/InterfaceSettings.module.css
+++ b/src/components/settings/InterfaceSettings.module.css
@@ -29,66 +29,9 @@
   text-transform: capitalize;
 }
 
-.themeCard {
-  display: flex;
-  flex-direction: column;
-  padding: 12px;
-  border-radius: 10px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-  &:hover {
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
-    transform: translateY(-2px);
-  }
-
-  .colorPreview {
-    display: flex;
-    flex-wrap: wrap;
-    padding-bottom: 8px;
-    margin-bottom: auto;
-    gap: 4px;
-  }
-
-  .colorBlock {
-    width: 20px;
-    height: 20px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-  }
-
-  .themeName {
-    margin-bottom: 4px;
-    text-transform: capitalize;
-    font-size: 14px;
-    font-weight: bold;
-  }
-
-  .maintainers {
-    margin-bottom: 8px;
-    opacity: 0.7;
-    font-size: 12px;
-    font-style: italic;
-  }
-}
-
 @media (max-width: 600px) {
   .themeGrid {
     width: 100%;
     grid-template-columns: 1fr;
-  }
-  .themeCard {
-    padding: 10px;
-  }
-
-  .colorPreview div {
-    width: 16px;
-    height: 16px;
-  }
-
-  button {
-    padding: 4px 6px;
-    font-size: 12px;
   }
 }

--- a/src/components/settings/InterfaceSettings.tsx
+++ b/src/components/settings/InterfaceSettings.tsx
@@ -14,9 +14,7 @@ import SettingsBlock from "../ui/settings-block/SettingsBlock";
 import { useWindowProperties } from "@/common/useWindowProperties";
 import {
   themePresets,
-  applyTheme,
   currentTheme,
-  customColors,
   setThemeColor,
   DefaultTheme,
   setCustomColors,
@@ -32,6 +30,8 @@ import { FlexColumn } from "../ui/Flexbox";
 import { timeFormat, setTimeFormat } from "@/common/date";
 import { toast } from "../ui/custom-portal/CustomPortal";
 import { RadioBoxItem } from "../ui/RadioBox";
+import ThemeCard from "../explore/ThemeCard";
+import cardStyle from "../explore/ThemeCard.module.css";
 
 export default function InterfaceSettings() {
   const { header } = useStore();
@@ -82,66 +82,21 @@ export function ThemesBlock() {
     >
       <div class={style.themeGrid}>
         <For each={Object.entries(themePresets)}>
-          {([name, { colors, maintainers }]) => {
-            const displayColors =
-              Object.keys(colors).length === 0
-                ? currentTheme()
-                : { ...DefaultTheme, ...colors };
-            return (
-              <div
-                class={style.themeCard}
-                style={{
-                  "background-color": colors["pane-color"],
-                  color: colors["text-color"] || DefaultTheme["text-color"]
-                }}
-              >
-                <div class={style.themeName}>{name}</div>
-                <Show when={maintainers.length}>
-                  <div class={style.maintainers}>
-                    {t("settings.interface.maintainers")}:{" "}
-                    {maintainers.join(", ")}
-                  </div>
-                </Show>
-                <div class={style.colorPreview}>
-                  <For each={Object.values(displayColors)}>
-                    {(color) => (
-                      <div
-                        class={style.colorBlock}
-                        style={{ "background-color": color }}
-                      />
-                    )}
-                  </For>
-                </div>
-                <Button
-                  label={t("settings.interface.apply")}
-                  onClick={() => applyTheme(name)}
-                />
-              </div>
-            );
+          {([name, theme]) => {
+            return <ThemeCard name={name} themeObj={theme} />;
           }}
         </For>
 
         <div
-          class={style.themeCard}
+          class={cardStyle.themeCard}
           style={{
             "background-color": "rgba(255,255,255,0.05)",
             "backdrop-filter": "blur(6px)",
-            display: "flex",
-            "flex-direction": "column",
             "justify-content": "center",
             "align-items": "center",
             position: "relative",
-            transition: "transform 0.2s, opacity 0.2s",
             border: "1px dashed rgba(255, 255, 255, 0.3)"
           }}
-          onMouseEnter={(e) =>
-            ((e.currentTarget as HTMLDivElement).style.transform =
-              "translateY(-3px)")
-          }
-          onMouseLeave={(e) =>
-            ((e.currentTarget as HTMLDivElement).style.transform =
-              "translateY(0)")
-          }
         >
           <div
             style={{


### PR DESCRIPTION
This makes the theme cards in the interface settings and in the explore page use the same component, and makes them mostly match in styling.

Style changes:
- The settings color block border color changes to match original explore styling
- The explore theme name and contributors change to match the ones in settings, with a larger font size

## Screenshots
Old:
<img height="882" src="https://github.com/user-attachments/assets/3b3d209e-c812-4fab-8448-48e1c8e705e7" />
New:
<img height="882" src="https://github.com/user-attachments/assets/e499a51a-312a-4dda-b1a6-bf2a5af54403" />

Old:
<img height="353" src="https://github.com/user-attachments/assets/6806c302-fe6c-4e0b-9623-21711a9bda5f" />
New:
<img height="353" src="https://github.com/user-attachments/assets/486a4473-0b83-4cbc-8095-a3f6edf41562" />

Old / New:
<img width="300" src="https://github.com/user-attachments/assets/107c8dff-8159-418d-becf-7c5f57ca71b4" /><img width="300" src="https://github.com/user-attachments/assets/147b87f0-ad0e-4ff0-8cb4-2b23ea7d4027" />

Old / New:
<img width="300" src="https://github.com/user-attachments/assets/ee474805-c528-4dfc-ac8b-4bf1a9eda0ce" /><img width="300" src="https://github.com/user-attachments/assets/4bf38a06-7d8d-4f62-adf9-4b7ae850df6d" />

## Did you test your code?
Tested on Firefox on Desktop, and Chrome on Android.

## Checklist
- [x] Changes are clear, concise, and easy to review
- [x] Code has been tested and works as intended
- [ ] ~~Text/content changes support internationalization (i18n)~~
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated theme card UI and styling into a reusable component used across Explore and Settings; unified theme state to a single theme preset model and removed duplicate inline styling.

* **New Features**
  * Theme cards now show name, optional maintainers, color previews, and an Apply action.
  * Added an "explore" visual variant for theme cards with responsive adjustments and hover visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->