### PR TITLE
chore: add <SettingsGroup> to auto-group settings blocks

### DIFF
--- a/src/components/settings/ActivityStatus.tsx
+++ b/src/components/settings/ActivityStatus.tsx
@@ -13,7 +13,7 @@ import { FlexColumn, FlexRow } from "../ui/Flexbox";
 import useStore from "@/chat-api/store/useStore";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import { Notice } from "../ui/Notice/Notice";
 import {
   electronWindowAPI,
@@ -293,12 +293,11 @@ function ProgramOptions() {
   };
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
         icon="gamepad"
         label={t("settings.activity.activityStatus")}
         description={t("settings.activity.activityStatusDescription")}
-        header={!!addedPrograms().length}
       >
         <Show when={addedPrograms().length + 1} keyed>
           <DropDown
@@ -313,10 +312,7 @@ function ProgramOptions() {
 
       <For each={addedPrograms()}>
         {(item, i) => (
-          <Block
-            borderTopRadius={false}
-            borderBottomRadius={i() === addedPrograms().length - 1}
-          >
+          <Block>
             <FlexRow
               gap={12}
               class={css`
@@ -365,7 +361,7 @@ function ProgramOptions() {
           </Block>
         )}
       </For>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 
@@ -419,26 +415,25 @@ const EditActivityStatusModal = (props: {
             value={newValues().name}
             onText={(v) => setValues({ ...newValues(), name: v })}
           />
-          <div>
+          <SettingsGroup>
             <SettingsBlock
-              header={showEmojiPicker()}
               label={t("settings.activity.activityStatusModal.emoji")}
               icon={emojiUrl() ? undefined : "face"}
               iconSrc={emojiUrl()}
               onClick={() => setShowEmojiPicker(!showEmojiPicker())}
               onClickIcon="keyboard_arrow_down"
             />
-            <div
-              style={{
-                background: "rgba(255, 255, 255, 0.05)",
-                "margin-top": "-1px",
-              }}
-            >
-              <Show when={showEmojiPicker()}>
+            <Show when={showEmojiPicker()}>
+              <Block
+                style={{
+                  "margin-top": "-1px",
+                  padding: "0",
+                }}
+              >
                 <EmojiPicker close={() => {}} onClick={emojiPicked} />
-              </Show>
-            </div>
-          </div>
+              </Block>
+            </Show>
+          </SettingsGroup>
         </FlexColumn>
       </Modal.Body>
       <Modal.Footer>
@@ -569,7 +564,6 @@ const LastFmActivity = () => {
     <SettingsBlock
       label={t("settings.activity.lastfmActivity")}
       description={t("settings.activity.lastfmActivityDescription")}
-      header
     >
       <FlexColumn gap={6}>
         <Input

--- a/src/components/settings/BadgeSettings.tsx
+++ b/src/components/settings/BadgeSettings.tsx
@@ -9,12 +9,13 @@ import { t } from "@nerimity/i18lite";
 import { electronWindowAPI } from "@/common/Electron";
 import { addBit, Bitwise, USER_BADGES, UserBadge } from "@/chat-api/Bitwise";
 import { RawUser } from "@/chat-api/RawData";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import { SelfUser } from "@/chat-api/events/connectionEventTypes";
 import Avatar from "../ui/Avatar";
 import { Notice } from "../ui/Notice/Notice";
 import { cn } from "@/common/classNames";
 import Icon from "../ui/icon/Icon";
+import Block from "../ui/settings-block/Block";
 
 const Container = styled("div")`
   display: flex;
@@ -97,21 +98,17 @@ const BadgesPreview = (props: { badges: Bitwise[]; price: number }) => {
 
   return (
     <Show when={user()}>
-      <div>
+      <SettingsGroup>
         <SettingsBlock
-          header
           label={t("settings.badges.price", { price: `$${props.price}` })}
           icon="favorite"
         />
-        <div
+        <Block
           class={css`
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(164px, 1fr));
             gap: 6px;
-            background: rgba(255, 255, 255, 0.05);
             justify-items: center;
-            border-bottom-left-radius: 8px;
-            border-bottom-right-radius: 8px;
             padding: 6px;
           `}
         >
@@ -125,8 +122,8 @@ const BadgesPreview = (props: { badges: Bitwise[]; price: number }) => {
               />
             )}
           </For>
-        </div>
-      </div>
+        </Block>
+      </SettingsGroup>
     </Show>
   );
 };
@@ -206,22 +203,18 @@ const BadgeItem = (props: {
 
 const SupportMethodBlock = () => {
   return (
-    <div>
+    <SettingsGroup>
       <SettingsBlock
         label={t("settings.badges.supportMethods")}
         icon="info"
-        header
       />
       <SettingsBlock
         label="Ko-Fi"
-        borderBottomRadius={false}
-        borderTopRadius={false}
         iconSrc="/assets/kofi.svg"
         href="https://ko-fi.com/supertiger"
         hrefBlank
       />
       <SettingsBlock
-        borderTopRadius={false}
         class={css`
           img {
             border-radius: 50%;
@@ -232,6 +225,6 @@ const SupportMethodBlock = () => {
         href="https://boosty.to/supertigerdev/donate"
         hrefBlank
       />
-    </div>
+    </SettingsGroup>
   );
 };

--- a/src/components/settings/CallSettings.tsx
+++ b/src/components/settings/CallSettings.tsx
@@ -7,7 +7,7 @@ import {
   onMount,
   Show
 } from "solid-js";
-import { css, styled } from "solid-styled-components";
+import { styled } from "solid-styled-components";
 import useStore from "@/chat-api/store/useStore";
 import {
   StorageKeys,
@@ -16,7 +16,7 @@ import {
 } from "@/common/localStorage";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import DropDown, { DropDownItem } from "../ui/drop-down/DropDown";
 import { Notice } from "../ui/Notice/Notice";
 import { electronWindowAPI } from "@/common/Electron";
@@ -27,6 +27,7 @@ import Button from "../ui/Button";
 import { downKeys, useGlobalKey } from "@/common/GlobalKey";
 import { toast } from "../ui/custom-portal/CustomPortal";
 import Checkbox from "../ui/Checkbox";
+import Block from "../ui/settings-block/Block";
 
 const Container = styled("div")`
   display: flex;
@@ -146,11 +147,10 @@ function InputDevices() {
   );
 
   return (
-    <div>
+    <SettingsGroup>
       <SettingsBlock
         icon="mic"
         label={t("settings.call.inputDevices")}
-        borderBottomRadius={!supportedConstraints().length}
       >
         <DropDown
           items={dropDownItem()}
@@ -161,11 +161,10 @@ function InputDevices() {
         />
       </SettingsBlock>
       <For each={supportedConstraints()}>
-        {(constraint, i) => (
+        {(constraint) => (
           <CheckboxOption
             constraint={constraint}
             checked={constraints()[constraint.key]}
-            bottomBorder={i() === supportedConstraints().length - 1}
             onChange={(val) => {
               setConstraints({
                 ...constraints(),
@@ -175,7 +174,7 @@ function InputDevices() {
           />
         )}
       </For>
-    </div>
+    </SettingsGroup>
   );
 }
 
@@ -222,14 +221,6 @@ function OutputDevices() {
   );
 }
 
-const InputModeRadioBoxContainer = styled(FlexColumn)`
-  background: rgba(255, 255, 255, 0.05);
-  padding: 10px;
-  border-bottom-left-radius: 6px;
-  border-bottom-right-radius: 6px;
-  padding-left: 50px;
-`;
-
 function InputMode() {
   const [inputMode, setInputMode] = useVoiceInputMode();
   const store = useStore();
@@ -237,18 +228,18 @@ function InputMode() {
   const isInCall = () => store.voiceUsers.currentUser()?.channelId;
 
   return (
-    <div>
+    <SettingsGroup>
       <SettingsBlock
         icon="steppers"
         label={t("settings.call.inputMode")}
-        header
       />
-      <InputModeRadioBoxContainer
+      <Block
         onClick={() => {
           if (isInCall()) {
             toast(t("settings.call.leaveCall"));
           }
         }}
+        style={{ "padding-left": "50px" }}
       >
         <RadioBox
           style={isInCall() ? { "pointer-events": "none" } : {}}
@@ -260,8 +251,8 @@ function InputMode() {
             { id: "PTT", label: t("settings.call.pushToTalk") }
           ]}
         />
-      </InputModeRadioBoxContainer>
-    </div>
+      </Block>
+    </SettingsGroup>
   );
 }
 
@@ -355,16 +346,13 @@ function CheckboxOption(props: {
   constraint: AvailableConstraint;
   onChange: (checked: boolean) => void;
   checked: boolean;
-  bottomBorder?: boolean;
 }) {
   return (
     <SettingsBlock
       icon={props.constraint.icon}
       label={t(props.constraint.label)}
-      borderTopRadius={false}
       description={props.constraint.description}
       onClick={() => props.onChange?.(!props.checked)}
-      borderBottomRadius={props.bottomBorder}
     >
       <Checkbox checked={props.checked} />
     </SettingsBlock>

--- a/src/components/settings/ConnectionsSettings.tsx
+++ b/src/components/settings/ConnectionsSettings.tsx
@@ -4,13 +4,12 @@ import { styled } from "solid-styled-components";
 import useStore from "@/chat-api/store/useStore";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import Button from "../ui/Button";
 import {
   createGoogleAccountLink,
   unlinkAccountWithGoogle,
 } from "@/chat-api/services/UserService";
-import { FlexColumn, FlexRow } from "../ui/Flexbox";
 import {
   OAuth2AuthorizedApplication,
   OAuth2AuthorizedApplications,
@@ -67,9 +66,8 @@ function ThirdPartyConnections() {
   });
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
-        header={connections().length > 0}
         icon="info"
         label={t("settings.connections.thirdParty.title")}
       >
@@ -78,7 +76,7 @@ function ThirdPartyConnections() {
         </Text>
       </SettingsBlock>
       <For each={connections()}>
-        {(connection, i) => (
+        {(connection) => (
           <ThirdPartyConnectionItem
             onUnauthorize={() => {
               setConnections(
@@ -86,17 +84,15 @@ function ThirdPartyConnections() {
               );
             }}
             connection={connection}
-            borderBottomRadius={i() === connections().length - 1}
           />
         )}
       </For>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 
 const ThirdPartyConnectionItem = (props: {
   connection: OAuth2AuthorizedApplication;
-  borderBottomRadius: boolean;
   onUnauthorize: () => void;
 }) => {
   const application = () => props.connection.application;
@@ -118,7 +114,6 @@ const ThirdPartyConnectionItem = (props: {
 
   return (
     <SettingsBlock
-      borderTopRadius={false}
       label={application().name}
       icon={
         <Avatar

--- a/src/components/settings/InterfaceSettings.tsx
+++ b/src/components/settings/InterfaceSettings.tsx
@@ -10,7 +10,7 @@ import {
 import Checkbox from "../ui/Checkbox";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import { useWindowProperties } from "@/common/useWindowProperties";
 import {
   themePresets,
@@ -26,7 +26,6 @@ import Button from "../ui/Button";
 import env from "@/common/env";
 import style from "./InterfaceSettings.module.css";
 import { useNavigate } from "solid-navigator";
-import { FlexColumn } from "../ui/Flexbox";
 import { timeFormat, setTimeFormat } from "@/common/date";
 import { toast } from "../ui/custom-portal/CustomPortal";
 import { RadioBoxItem } from "../ui/RadioBox";
@@ -195,19 +194,16 @@ function ChatBar() {
   type OptionIds = ["vm", "gif", "emoji", "send"];
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
         icon="chat"
         label={t("settings.interface.chatBarOptions")}
-        header
       />
       <For each={options}>
         {({ icon, label, id }) => (
           <SettingsBlock
             icon={icon}
             label={label}
-            borderTopRadius={false}
-            borderBottomRadius={false}
             onClick={() => {
               const options = chatBarOptions() as unknown as OptionIds[];
               if (chatBarOptions().includes(id)) {
@@ -234,11 +230,10 @@ function ChatBar() {
         description={t(
           "settings.interface.disableAdvancedMarkupBarDescription"
         )}
-        borderTopRadius={false}
       >
         <Checkbox onChange={setEnabled} checked={enabled()} />
       </SettingsBlock>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 
@@ -310,12 +305,11 @@ function CustomizeColors() {
   };
 
   return (
-    <div>
+    <SettingsGroup>
       <SettingsBlock
         icon="palette"
         label={t("settings.interface.customizeColors")}
         description={t("settings.interface.customizeColorsDescription")}
-        header
       >
         <Button
           label={t("settings.interface.exportButton")}
@@ -342,10 +336,6 @@ function CustomizeColors() {
               icon="colors"
               class={style.themeItem}
               label={token.key.replaceAll("-", " ")}
-              borderBottomRadius={
-                i() === Object.keys(currentTheme()).length - 1
-              }
-              borderTopRadius={false}
             >
               <Show
                 when={
@@ -371,26 +361,23 @@ function CustomizeColors() {
           </>
         )}
       </For>
-    </div>
+    </SettingsGroup>
   );
 }
 
 function RightDrawerModeBlock() {
   const [mode, setMode] = rightDrawerMode;
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
         icon="right_panel_open"
         label={t("settings.interface.rightDrawerMode")}
-        header
       />
 
       <SettingsBlock
         label={t("settings.interface.swipeToOpen")}
         description={t("settings.interface.swipeToOpenDescription")}
         icon="swipe"
-        borderTopRadius={false}
-        borderBottomRadius={false}
         onClick={() => {
           setMode("SWIPE");
         }}
@@ -404,7 +391,6 @@ function RightDrawerModeBlock() {
         label={t("settings.interface.headerTapToOpen")}
         description={t("settings.interface.headerTapToOpenDescription")}
         icon="highlight_mouse_cursor"
-        borderTopRadius={false}
         onClick={() => {
           setMode("HEADER_CLICK");
         }}
@@ -414,6 +400,6 @@ function RightDrawerModeBlock() {
           item={{ id: 0, label: "" }}
         />
       </SettingsBlock>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }

--- a/src/components/settings/NotificationsSettings.tsx
+++ b/src/components/settings/NotificationsSettings.tsx
@@ -1,7 +1,6 @@
 import { createEffect, createSignal, Show } from "solid-js";
 import Text from "@/components/ui/Text";
-import { css, styled } from "solid-styled-components";
-import { FlexColumn } from "../ui/Flexbox";
+import { styled } from "solid-styled-components";
 import useStore from "@/chat-api/store/useStore";
 import {
   getStorageBoolean,
@@ -14,7 +13,7 @@ import {
 import Checkbox from "../ui/Checkbox";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import Slider from "../ui/Slider";
 import {
   getCustomSound,
@@ -25,6 +24,7 @@ import {
 import DropDown from "../ui/drop-down/DropDown";
 import Button from "../ui/Button";
 import { RadioBox, RadioBoxItem } from "../ui/RadioBox";
+import Block from "../ui/settings-block/Block";
 
 const Container = styled("div")`
   display: flex;
@@ -107,7 +107,7 @@ function NotificationSound() {
   };
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
         icon="notifications_active"
         label={t("settings.notifications.sounds")}
@@ -136,15 +136,14 @@ function NotificationSound() {
           </div>
         </SettingsBlock>
       </Show>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 
 function NotificationSoundSelection() {
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
-        header
         icon="music_note"
         label={t("settings.notifications.sounds")}
         description={t("settings.notifications.changeSoundsDescription")}
@@ -153,8 +152,6 @@ function NotificationSoundSelection() {
         icon="chat"
         label={t("settings.notifications.message")}
         description={t("settings.notifications.messageDescription")}
-        borderTopRadius={false}
-        borderBottomRadius={false}
       >
         <NotificationSoundDropDown typeId="MESSAGE" />
       </SettingsBlock>
@@ -162,8 +159,6 @@ function NotificationSoundSelection() {
         icon="alternate_email"
         label={t("settings.notifications.mention")}
         description={t("settings.notifications.mentionDescription")}
-        borderTopRadius={false}
-        borderBottomRadius={false}
       >
         <NotificationSoundDropDown typeId="MESSAGE_MENTION" />
       </SettingsBlock>
@@ -171,27 +166,22 @@ function NotificationSoundSelection() {
         icon="calendar_today"
         label={t("settings.notifications.reminder")}
         description={t("settings.notifications.reminderDescription")}
-        borderTopRadius={false}
-        borderBottomRadius={false}
       >
         <NotificationSoundDropDown typeId="REMINDER" />
       </SettingsBlock>
       <SettingsBlock
         icon="call"
         label={t("settings.notifications.callJoin")}
-        borderTopRadius={false}
-        borderBottomRadius={false}
       >
         <NotificationSoundDropDown typeId="CALL_JOIN" />
       </SettingsBlock>
       <SettingsBlock
         icon="call_end"
         label={t("settings.notifications.callLeave")}
-        borderTopRadius={false}
       >
         <NotificationSoundDropDown typeId="CALL_LEAVE" />
       </SettingsBlock>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 
@@ -248,15 +238,6 @@ function NotificationSoundDropDown(props: {
   );
 }
 
-const RadioBoxContainer = styled("div")`
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.4);
-  background: rgba(255, 255, 255, 0.05);
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  padding: 10px;
-  padding-left: 50px;
-`;
-
 function InAppNotificationBlock() {
   const [value, setValue] = useLocalStorage(
     StorageKeys.IN_APP_NOTIFICATIONS_PREVIEW,
@@ -278,24 +259,20 @@ function InAppNotificationBlock() {
   ];
 
   return (
-    <div>
+    <SettingsGroup>
       <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
-        header
         icon="priority_high"
         label={t("settings.notifications.inAppPreview")}
         description={t("settings.notifications.inAppPreviewDescription")}
       />
 
-      <RadioBoxContainer>
+      <Block style={{ "padding-left": "50px" }}>
         <RadioBox
           onChange={(e) => setValue(e.id)}
           items={NotificationPingItems}
           initialId={value()}
         />
-      </RadioBoxContainer>
-    </div>
+      </Block>
+    </SettingsGroup>
   );
 }

--- a/src/components/settings/PrivacySettings.tsx
+++ b/src/components/settings/PrivacySettings.tsx
@@ -5,10 +5,11 @@ import { FlexColumn } from "../ui/Flexbox";
 import useStore from "@/chat-api/store/useStore";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import { RadioBox, RadioBoxItem } from "../ui/RadioBox";
 import { updateUser } from "@/chat-api/services/UserService";
 import Checkbox from "../ui/Checkbox";
+import Block from "../ui/settings-block/Block";
 
 const Container = styled("div")`
   display: flex;
@@ -17,12 +18,7 @@ const Container = styled("div")`
   padding: 10px;
 `;
 
-const RadioBoxContainer = styled("div")`
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.4);
-  background: rgba(255, 255, 255, 0.05);
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  padding: 10px;
+const RadioBoxContainer = styled(Block)`
   padding-left: 50px;
 `;
 
@@ -69,13 +65,9 @@ function LastOnlineOptions() {
   };
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
         description={t("settings.privacy.lastOnline.description")}
-        header
         icon="schedule"
         label={t("settings.privacy.lastOnline.title")}
       />
@@ -86,7 +78,7 @@ function LastOnlineOptions() {
           initialId={friendRequestStatus() || 0}
         />
       </RadioBoxContainer>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 
@@ -109,26 +101,23 @@ function DMOptions() {
   };
 
   return (
-    <FlexColumn>
+    <>
       <DirectMessageBlock />
-
-      <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
-        description={t("settings.privacy.friendRequest.description")}
-        header
-        icon="group_add"
-        label={t("settings.privacy.friendRequest.title")}
-      />
-      <RadioBoxContainer>
-        <RadioBox
-          onChange={onChange}
-          items={radioboxItems}
-          initialId={friendRequestStatus() || 0}
+      <SettingsGroup>
+        <SettingsBlock
+          description={t("settings.privacy.friendRequest.description")}
+          icon="group_add"
+          label={t("settings.privacy.friendRequest.title")}
         />
-      </RadioBoxContainer>
-    </FlexColumn>
+        <RadioBoxContainer>
+          <RadioBox
+            onChange={onChange}
+            items={radioboxItems}
+            initialId={friendRequestStatus() || 0}
+          />
+        </RadioBoxContainer>
+      </SettingsGroup>
+    </>
   );
 }
 
@@ -150,13 +139,9 @@ const DirectMessageBlock = () => {
     });
   };
   return (
-    <>
+    <SettingsGroup>
       <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
         description={t("settings.privacy.directMessage.description")}
-        header
         icon="chat_bubble"
         label={t("settings.privacy.directMessage.title")}
       />
@@ -167,7 +152,7 @@ const DirectMessageBlock = () => {
           initialId={currentDmStatus() || 0}
         />
       </RadioBoxContainer>
-    </>
+    </SettingsGroup>
   );
 };
 
@@ -200,12 +185,8 @@ const ProfileOptions = () => {
   };
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
-        header
         icon="person"
         label={t("settings.privacy.profileOptions.title")}
       />
@@ -214,8 +195,6 @@ const ProfileOptions = () => {
         description={t(
           "settings.privacy.profileOptions.hideFollowersDescription"
         )}
-        borderBottomRadius={false}
-        borderTopRadius={false}
       >
         <Checkbox checked={hideFollowers()} onChange={onChange("followers")} />
       </SettingsBlock>
@@ -224,10 +203,9 @@ const ProfileOptions = () => {
         description={t(
           "settings.privacy.profileOptions.hideFollowingDescription"
         )}
-        borderTopRadius={false}
       >
         <Checkbox checked={hideFollowing()} onChange={onChange("following")} />
       </SettingsBlock>
-    </FlexColumn>
+    </SettingsGroup>
   );
 };

--- a/src/components/settings/WindowSettings.tsx
+++ b/src/components/settings/WindowSettings.tsx
@@ -1,12 +1,11 @@
 import { createEffect, createSignal, onMount, Show } from "solid-js";
 import { styled } from "solid-styled-components";
 
-import { FlexColumn } from "../ui/Flexbox";
 import useStore from "@/chat-api/store/useStore";
 import Checkbox from "../ui/Checkbox";
 import Breadcrumb, { BreadcrumbItem } from "../ui/Breadcrumb";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 
 import { Notice } from "../ui/Notice/Notice";
 import { electronWindowAPI } from "@/common/Electron";
@@ -90,14 +89,12 @@ function StartupOptions() {
   };
 
   return (
-    <FlexColumn>
-      <SettingsBlock icon="open_in_new" label={t("settings.window.startupOptions")} header />
+    <SettingsGroup>
+      <SettingsBlock icon="open_in_new" label={t("settings.window.startupOptions")} />
       <SettingsBlock
         onClick={() => onAutostartChange(!autostart())}
         icon="restart_alt"
         label={t("settings.window.openOnStartup")}
-        borderTopRadius={false}
-        borderBottomRadius={!autostart()}
       >
         <Checkbox checked={autostart()} onChange={onAutostartChange} />
       </SettingsBlock>
@@ -107,7 +104,6 @@ function StartupOptions() {
           icon="horizontal_rule"
           label={t("settings.window.startMinimized")}
           description={t("settings.window.startMinimizedDescription")}
-          borderTopRadius={false}
         >
           <Checkbox
             checked={autostartMinimized()}
@@ -115,7 +111,7 @@ function StartupOptions() {
           />
         </SettingsBlock>
       </Show>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 function HardwareAccelerationOptions() {
@@ -134,7 +130,7 @@ function HardwareAccelerationOptions() {
   };
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
         onClick={() =>
           onHardwareAccelerationChange(!hardwareAccelerationDisabled())
@@ -145,7 +141,7 @@ function HardwareAccelerationOptions() {
       >
         <Checkbox checked={hardwareAccelerationDisabled()} />
       </SettingsBlock>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }
 function DisableCustomTitlebar() {
@@ -164,7 +160,7 @@ function DisableCustomTitlebar() {
   };
 
   return (
-    <FlexColumn>
+    <SettingsGroup>
       <SettingsBlock
         onClick={() => onChange(!customTitlebarDisabled())}
         icon="speed"
@@ -173,6 +169,6 @@ function DisableCustomTitlebar() {
       >
         <Checkbox checked={customTitlebarDisabled()} />
       </SettingsBlock>
-    </FlexColumn>
+    </SettingsGroup>
   );
 }

--- a/src/components/ui/settings-block/Block.tsx
+++ b/src/components/ui/settings-block/Block.tsx
@@ -4,22 +4,26 @@ import { classNames, conditionalClass } from "@/common/classNames";
 import { css } from "solid-styled-components";
 
 interface BlockProps {
-  children?: JSX.Element | undefined;
   class?: string;
+  children?: JSX.Element | undefined;
+  style?: JSX.CSSProperties;
   borderTopRadius?: boolean
   borderBottomRadius?: boolean
+  onClick?: () => void;
 }
 
 export default function Block(props: BlockProps) {
   return (
-    <div class={
-      classNames(
+    <div
+      onClick={props.onClick}
+      class={classNames(
         styles.block,
-        conditionalClass(props.borderTopRadius === false, css`&& {border-top-left-radius: 0; border-top-right-radius: 0; margin-top: 0;}`),
-        conditionalClass(props.borderBottomRadius === false, css`&& {border-bottom-left-radius: 0; border-bottom-right-radius: 0; margin-bottom: 0;}`),
-        conditionalClass(props.borderBottomRadius === false && props.borderTopRadius === false, css`&& {margin-bottom: 1px;}`),
+        conditionalClass(props.borderTopRadius === false, styles.joinTop),
+        conditionalClass(props.borderBottomRadius === false, styles.joinBottom),
         props.class
-      )}>
+      )}
+      style={props.style}
+    >
       {props.children}
     </div>
   );

--- a/src/components/ui/settings-block/SettingsBlock.tsx
+++ b/src/components/ui/settings-block/SettingsBlock.tsx
@@ -2,7 +2,6 @@ import styles from "./styles.module.scss";
 import { JSX, JSXElement, Show, children } from "solid-js";
 import Icon from "@/components/ui/icon/Icon";
 import { classNames, conditionalClass } from "@/common/classNames";
-import { css } from "solid-styled-components";
 import { Dynamic } from "solid-js/web";
 import { CustomLink } from "../CustomLink";
 
@@ -39,35 +38,9 @@ export default function SettingsBlock(props: BlockProps) {
       href={props.href}
       class={classNames(
         styles.block,
-        conditionalClass(props.header, styles.header!),
-        conditionalClass(
-          props.borderTopRadius === false,
-          css`
-            && {
-              border-top-left-radius: 0;
-              border-top-right-radius: 0;
-              margin-top: 0;
-            }
-          `
-        ),
-        conditionalClass(
-          props.borderBottomRadius === false,
-          css`
-            && {
-              border-bottom-left-radius: 0;
-              border-bottom-right-radius: 0;
-              margin-bottom: 0;
-            }
-          `
-        ),
-        conditionalClass(
-          props.borderBottomRadius === false && props.borderTopRadius === false,
-          css`
-            && {
-              margin-bottom: 1px;
-            }
-          `
-        ),
+        conditionalClass(props.header, styles.header),
+        conditionalClass(props.borderTopRadius === false, styles.joinTop),
+        conditionalClass(props.borderBottomRadius === false, styles.joinBottom),
         conditionalClass(props.onClick || props.href, styles.clickable!),
         props.class
       )}
@@ -107,5 +80,26 @@ export default function SettingsBlock(props: BlockProps) {
         />
       </Show>
     </Dynamic>
+  );
+}
+
+interface GroupProps {
+  children: JSX.Element;
+  class?: string;
+  style?: JSX.CSSProperties;
+}
+
+export function SettingsGroup(props: GroupProps) {
+  const resolved = children(() => props.children);
+  return (
+    <div
+      class={classNames(
+        styles.group,
+        props.class
+      )}
+      style={props.style}
+    >
+      {resolved()}
+    </div>
   );
 }

--- a/src/components/ui/settings-block/styles.module.scss
+++ b/src/components/ui/settings-block/styles.module.scss
@@ -14,10 +14,28 @@
       background: rgba(255, 255, 255, 0.1);
     }
   }
-  &.header {
-    margin-bottom: 1px;
-    border-bottom-right-radius: 0;
+  &.joinTop {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin-top: 0;
+  }
+  &.joinBottom, &.header {
     border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-bottom: 1px;
+  }
+}
+
+.group > .block {
+  &:not(:first-child) {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin-top: 0;
+  }
+  &:not(:last-child) {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-bottom: 1px;
   }
 }
 


### PR DESCRIPTION
This adds a `<SettingsGroup>` component to handle styling the grouping of setting blocks automatically, and then refactors the main settings page to use the new groups.  This doesn't refactor server settings / application settings / moderation; those are for future PRs.

This is also partial prep-work for making the gaps between settings blocks more consistent, but that's also for a future PR.  This PR causes some minor changes to the spacing between settings blocks in some cases, but the spacing is already inconsistent, so it shouldn't be much of an issue.

## Did you test your code?
Tested on Firefox on Linux and Chrome on Android.  Note that this refactors the activity status modal, which only normally appears on the desktop app.  I manually enabled it for testing, but I don't know how you'd properly test local changes on the desktop app.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings pages now use a unified grouping container for related options for more consistent grouping.
  * Sections like emoji picker, badges, connections, and various option groups are visually consolidated into grouped blocks.
  * Removed redundant per-item headers and rounded-edge inconsistencies; section borders and spacing simplified.
  * Overall visual spacing, alignment, and click targets improved across all settings panels; no changes to settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->