### PR TITLE
chore: use <SettingsGroup> in server settings

### DIFF
--- a/src/components/guild-join-notification-modal/GuildJoinNotificationModal.tsx
+++ b/src/components/guild-join-notification-modal/GuildJoinNotificationModal.tsx
@@ -1,23 +1,22 @@
 import style from "./GuildJoinNotificationModal.module.css";
-import { createEffect, Show } from "solid-js";
+import { createEffect, JSXElement, Show } from "solid-js";
 import { Modal } from "../ui/modal";
 import useStore from "@/chat-api/store/useStore";
-import SettingsBlock from "../ui/settings-block/SettingsBlock";
-import { css, styled } from "solid-styled-components";
+import SettingsBlock, { SettingsGroup } from "../ui/settings-block/SettingsBlock";
 import ItemContainer from "@/components/ui/LegacyItem";
 import { t } from "@nerimity/i18lite";
 import Avatar from "../ui/Avatar";
 import { RadioBox, RadioBoxItem } from "../ui/RadioBox";
 import { ServerNotificationPingMode } from "@/chat-api/RawData";
+import Block from "../ui/settings-block/Block";
 
-const RadioBoxContainer = styled("div")`
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.4);
-  background: rgba(255, 255, 255, 0.05);
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  padding: 10px;
-  padding-left: 50px;
-`;
+const RadioBoxContainer = (props: { children?: JSXElement }) => {
+  return (
+    <Block style={{ "padding-left": "50px", "margin-bottom": "0" }}>
+      {props.children}
+    </Block>
+  );
+};
 
 export default function GuildJoinNotificationModal(props: {
   close: () => void;
@@ -90,9 +89,8 @@ export default function GuildJoinNotificationModal(props: {
     >
       <Modal.Header title="Notification Settings" icon="notifications" />
       <Modal.Body class={style.body}>
-        <div>
+        <SettingsGroup>
           <SettingsBlock
-            header
             icon="priority_high"
             label={t("servers.settings.notifications.ping")}
             description={t("servers.settings.notifications.pingDescription")}
@@ -115,16 +113,15 @@ export default function GuildJoinNotificationModal(props: {
               initialId={currentNotificationPingMode()}
             />
           </RadioBoxContainer>
-        </div>
+        </SettingsGroup>
 
         <Show
           when={
             currentNotificationPingMode() !== ServerNotificationPingMode.MUTE
           }
         >
-          <div>
+          <SettingsGroup>
             <SettingsBlock
-              header
               icon="notifications_active"
               label={t("servers.settings.notifications.sound")}
               description={t("servers.settings.notifications.soundDescription")}
@@ -136,7 +133,7 @@ export default function GuildJoinNotificationModal(props: {
                 initialId={currentNotificationSoundMode()}
               />
             </RadioBoxContainer>
-          </div>
+          </SettingsGroup>
         </Show>
       </Modal.Body>
       <Modal.Footer>

--- a/src/components/servers/settings/ServerNotificationSettings.tsx
+++ b/src/components/servers/settings/ServerNotificationSettings.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "solid-navigator";
-import { For, Show, createEffect } from "solid-js";
+import { For, JSXElement, Show, createEffect } from "solid-js";
 import useStore from "@/chat-api/store/useStore";
-import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "@/components/ui/settings-block/SettingsBlock";
 import { css, styled } from "solid-styled-components";
 import { t } from "@nerimity/i18lite";
 import Breadcrumb, { BreadcrumbItem } from "@/components/ui/Breadcrumb";
@@ -17,21 +17,22 @@ import {
   ServerNotificationSoundMode
 } from "@/chat-api/RawData";
 import Button from "@/components/ui/Button";
+import Block from "@/components/ui/settings-block/Block";
 
 const Container = styled("div")`
   display: flex;
   flex-direction: column;
   padding: 10px;
+  gap: 10px;
 `;
 
-const RadioBoxContainer = styled("div")`
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.4);
-  background: rgba(255, 255, 255, 0.05);
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  padding: 10px;
-  padding-left: 50px;
-`;
+const RadioBoxContainer = (props: { children?: JSXElement }) => {
+  return (
+    <Block style={{ "padding-left": "50px", "margin-bottom": "0" }}>
+      {props.children}
+    </Block>
+  );
+};
 
 export default function ServerNotificationSettings() {
   const params = useParams<{ serverId: string; channelId?: string }>();
@@ -135,52 +136,49 @@ export default function ServerNotificationSettings() {
         type="info"
         description={t("servers.settings.notifications.notice")}
       />
-      <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
-        header
-        icon="priority_high"
-        label={t("servers.settings.notifications.ping")}
-        description={t("servers.settings.notifications.pingDescription")}
-      >
-        <ItemContainer
-          alert={
-            currentNotificationPingMode() !== ServerNotificationPingMode.MUTE
-          }
-          style={{ "padding-left": "10px", "pointer-events": "none" }}
-        >
-          <Avatar server={server()} size={30} />
-        </ItemContainer>
-      </SettingsBlock>
 
-      <RadioBoxContainer>
-        <RadioBox
-          onChange={onNotificationPingChange}
-          items={NotificationPingItems}
-          initialId={currentNotificationPingMode()}
-        />
-      </RadioBoxContainer>
+      <SettingsGroup>
+        <SettingsBlock
+          icon="priority_high"
+          label={t("servers.settings.notifications.ping")}
+          description={t("servers.settings.notifications.pingDescription")}
+        >
+          <ItemContainer
+            alert={
+              currentNotificationPingMode() !== ServerNotificationPingMode.MUTE
+            }
+            style={{ "padding-left": "10px", "pointer-events": "none" }}
+          >
+            <Avatar server={server()} size={30} />
+          </ItemContainer>
+        </SettingsBlock>
+
+        <RadioBoxContainer>
+          <RadioBox
+            onChange={onNotificationPingChange}
+            items={NotificationPingItems}
+            initialId={currentNotificationPingMode()}
+          />
+        </RadioBoxContainer>
+      </SettingsGroup>
 
       <Show
         when={currentNotificationPingMode() !== ServerNotificationPingMode.MUTE}
       >
-        <SettingsBlock
-          class={css`
-            margin-top: 10px;
-          `}
-          header
-          icon="notifications_active"
-          label={t("servers.settings.notifications.sound")}
-          description={t("servers.settings.notifications.soundDescription")}
-        />
-        <RadioBoxContainer>
-          <RadioBox
-            onChange={onNotificationSoundChange}
-            items={NotificationSoundItems()}
-            initialId={currentNotificationSoundMode()}
+        <SettingsGroup>
+          <SettingsBlock
+            icon="notifications_active"
+            label={t("servers.settings.notifications.sound")}
+            description={t("servers.settings.notifications.soundDescription")}
           />
-        </RadioBoxContainer>
+          <RadioBoxContainer>
+            <RadioBox
+              onChange={onNotificationSoundChange}
+              items={NotificationSoundItems()}
+              initialId={currentNotificationSoundMode()}
+            />
+          </RadioBoxContainer>
+        </SettingsGroup>
       </Show>
 
       <Show when={!channel()?.serverId}>
@@ -233,12 +231,8 @@ const ChannelNotificationsBlock = () => {
   ];
 
   return (
-    <>
+    <SettingsGroup>
       <SettingsBlock
-        class={css`
-          margin-top: 10px;
-        `}
-        header
         icon="storage"
         label={t("servers.settings.drawer.channels")}
         description={t("servers.settings.notifications.channelsDescription")}
@@ -255,20 +249,17 @@ const ChannelNotificationsBlock = () => {
       </SettingsBlock>
 
       <For each={sortedChannels()}>
-        {(channel, i) => (
+        {(channel) => (
           <SettingsBlock
             href={"./" + channel.id}
             class={css`
-              padding-top: 0;
-              padding-bottom: 0;
+              padding-block: 0;
             `}
             label={`${hasOverride(channel.id) ? "*" : ""}${channel.name}`}
             icon="tag"
-            borderTopRadius={false}
-            borderBottomRadius={i() === sortedChannels().length - 1}
           />
         )}
       </For>
-    </>
+    </SettingsGroup>
   );
 };

--- a/src/components/servers/settings/channel/ServerSettingsChannel.tsx
+++ b/src/components/servers/settings/channel/ServerSettingsChannel.tsx
@@ -13,7 +13,7 @@ import {
 } from "solid-js";
 import useStore from "@/chat-api/store/useStore";
 import { createUpdatedSignal } from "@/common/createUpdatedSignal";
-import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "@/components/ui/settings-block/SettingsBlock";
 import Input from "@/components/ui/input/Input";
 import Button from "@/components/ui/Button";
 import {
@@ -240,36 +240,37 @@ function PermissionsTab() {
 
   return (
     <div class={styles.channelPane}>
-      <SettingsBlock
-        icon="security"
-        label={t("servers.settings.drawer.permissions")}
-        description={t("servers.settings.channel.permissionsDescription")}
-        header={true}
-        class={css`
-          && {
-            flex-direction: column;
-            align-items: start;
-            gap: 6px;
-          }
-        `}
-      >
-        <DropDown
+      <SettingsGroup>
+        <SettingsBlock
+          icon="security"
+          label={t("servers.settings.drawer.permissions")}
+          description={t("servers.settings.channel.permissionsDescription")}
           class={css`
-            align-self: stretch;
-            margin-left: 40px;
+            && {
+              flex-direction: column;
+              align-items: start;
+              gap: 6px;
+            }
           `}
-          items={rolesDropdownItems()}
-          selectedId={selectedRoleId()}
-          onChange={(item) => setSelectedRoleId(item.id)}
-        />
-      </SettingsBlock>
+        >
+          <DropDown
+            class={css`
+              align-self: stretch;
+              margin-left: 40px;
+            `}
+            items={rolesDropdownItems()}
+            selectedId={selectedRoleId()}
+            onChange={(item) => setSelectedRoleId(item.id)}
+          />
+        </SettingsBlock>
 
-      <Show when={selectedRoleId()} keyed>
-        <ChannelPermissionsBlock
-          permissions={permissions()}
-          setPermissions={setPermissions}
-        />
-      </Show>
+        <Show when={selectedRoleId()} keyed>
+          <ChannelPermissionsBlock
+            permissions={permissions()}
+            setPermissions={setPermissions}
+          />
+        </Show>
+      </SettingsGroup>
 
       <FloatingSaveChanges
         error={error()}
@@ -672,25 +673,22 @@ const WebhooksBlock = (props: { channelId: string; serverId: string }) => {
   };
 
   return (
-    <div>
+    <SettingsGroup>
       <SettingsBlock
         icon="webhook"
         label="Webhooks"
-        header={!!webhooks().length}
       >
         <Button label="Create" iconName="add" onClick={handleCreate} />
       </SettingsBlock>
       <For each={webhooks()}>
-        {(webhook, i) => (
+        {(webhook) => (
           <SettingsBlock
             icon="webhook"
             label={webhook.name}
-            borderTopRadius={false}
             href={`./webhooks/${webhook.id}`}
-            borderBottomRadius={i() === webhooks().length - 1}
           />
         )}
       </For>
-    </div>
+    </SettingsGroup>
   );
 };

--- a/src/components/servers/settings/channel/styles.module.scss
+++ b/src/components/servers/settings/channel/styles.module.scss
@@ -41,15 +41,6 @@
   align-self: flex-end;
 }
 
-.permissionItem {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  &:not(:last-child) {
-    margin-bottom: 1px;
-    border-radius: 0;
-  }
-}
-
 .slowdownInput {
   width: 84px;
 }

--- a/src/components/servers/settings/invites/ServerSettingsInvite.tsx
+++ b/src/components/servers/settings/invites/ServerSettingsInvite.tsx
@@ -16,7 +16,7 @@ import { A, useNavigate, useParams } from "solid-navigator";
 import { createEffect, createSignal, For, on, onMount, Show } from "solid-js";
 import useStore from "@/chat-api/store/useStore";
 import { useWindowProperties } from "@/common/useWindowProperties";
-import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "@/components/ui/settings-block/SettingsBlock";
 import { copyToClipboard } from "@/common/clipboard";
 import { FlexColumn, FlexRow } from "@/components/ui/Flexbox";
 import Input from "@/components/ui/input/Input";
@@ -26,6 +26,7 @@ import Text from "@/components/ui/Text";
 import { useTransContext } from "@nerimity/solid-i18lite";
 import { avatarUrl } from "@/chat-api/store/useUsers";
 import Breadcrumb, { BreadcrumbItem } from "@/components/ui/Breadcrumb";
+import Block from "@/components/ui/settings-block/Block";
 
 export default function ServerSettingsInvite() {
   const [t] = useTransContext();
@@ -98,25 +99,26 @@ export default function ServerSettingsInvite() {
         <CustomInvite invites={invites()} onUpdate={fetchInvites} />
       </Show>
 
-      <SettingsBlock
-        label={t("servers.settings.invites.serverInvites")}
-        description={t("servers.settings.invites.serverInvitesDescription")}
-        icon="mail"
-        header={true}
-      >
-        <Button
-          label={t("servers.settings.invites.createInviteButton")}
-          onClick={onCreateInviteClick}
-        />
-      </SettingsBlock>
-      <For each={invites()}>
-        {(invite) => (
-          <InviteItem
-            invite={invite}
-            onDeleted={() => deleteInvite(invite.code)}
+      <SettingsGroup>
+        <SettingsBlock
+          label={t("servers.settings.invites.serverInvites")}
+          description={t("servers.settings.invites.serverInvitesDescription")}
+          icon="mail"
+        >
+          <Button
+            label={t("servers.settings.invites.createInviteButton")}
+            onClick={onCreateInviteClick}
           />
-        )}
-      </For>
+        </SettingsBlock>
+        <For each={invites()}>
+          {(invite) => (
+            <InviteItem
+              invite={invite}
+              onDeleted={() => deleteInvite(invite.code)}
+            />
+          )}
+        </For>
+      </SettingsGroup>
     </div>
   );
 }
@@ -242,7 +244,7 @@ const InviteItem = (props: { invite: any; onDeleted: () => void }) => {
   };
 
   return (
-    <div class={styles.inviteItem}>
+    <Block class={styles.inviteItem}>
       <Avatar class={styles.avatar} user={props.invite.createdBy} size={30} />
       <div class={styles.detailsOuter}>
         <div class={styles.details}>
@@ -300,6 +302,6 @@ const InviteItem = (props: { invite: any; onDeleted: () => void }) => {
           />
         </FlexRow>
       </div>
-    </div>
+    </Block>
   );
 };

--- a/src/components/servers/settings/invites/styles.module.scss
+++ b/src/components/servers/settings/invites/styles.module.scss
@@ -29,21 +29,9 @@
 }
 
 .inviteItem {
-  display: flex;
-  align-items: center;
-  padding: 10px;
-
-  margin-bottom: 2px;
-  border-bottom-right-radius: 8px;
-
-  border-bottom-left-radius: 8px;
-  background: rgba(255, 255, 255, 0.06);
+  padding-left: 10px;
   gap: 6px;
 
-  &:not(:last-child) {
-    margin-bottom: 1px;
-    border-radius: 0;
-  }
   .avatar {
     align-self: start;
     margin-top: 4px;

--- a/src/components/servers/settings/role/ServerSettingsRole.tsx
+++ b/src/components/servers/settings/role/ServerSettingsRole.tsx
@@ -12,7 +12,7 @@ import {
 } from "solid-js";
 import useStore from "@/chat-api/store/useStore";
 import { createUpdatedSignal } from "@/common/createUpdatedSignal";
-import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "@/components/ui/settings-block/SettingsBlock";
 import Input from "@/components/ui/input/Input";
 import Button from "@/components/ui/Button";
 import {
@@ -315,12 +315,11 @@ export default function ServerSettingsRole() {
         />
       </SettingsBlock>
 
-      <div class={styles.permissions}>
+      <SettingsGroup class={styles.permissions}>
         <SettingsBlock
           icon="security"
           label={t("servers.settings.drawer.permissions")}
           description={t("servers.settings.role.permissionsDescription")}
-          header={true}
         />
         <For each={permissions()}>
           {(permission) => (
@@ -328,7 +327,6 @@ export default function ServerSettingsRole() {
               icon={permission.icon}
               label={permission.name()}
               description={permission.description?.()}
-              class={styles.permissionItem}
               onClick={() =>
                 onPermissionChanged(!permission.hasPerm, permission.bit)
               }
@@ -337,7 +335,7 @@ export default function ServerSettingsRole() {
             </SettingsBlock>
           )}
         </For>
-      </div>
+      </SettingsGroup>
 
       {/* Delete Role */}
       <SettingsBlock

--- a/src/components/servers/settings/role/styles.module.scss
+++ b/src/components/servers/settings/role/styles.module.scss
@@ -24,15 +24,6 @@
   align-self: flex-end;
 }
 
-.permissionItem {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  &:not(:last-child) {
-    margin-bottom: 1px;
-    border-radius: 0;
-  }
-}
-
 .permissions {
   margin-top: 5px;
   margin-bottom: 5px;

--- a/src/components/servers/settings/welcome-question/WelcomeQuestion.tsx
+++ b/src/components/servers/settings/welcome-question/WelcomeQuestion.tsx
@@ -22,7 +22,7 @@ import { useCustomPortal } from "@/components/ui/custom-portal/CustomPortal";
 import Breadcrumb, { BreadcrumbItem } from "@/components/ui/Breadcrumb";
 import RouterEndpoints from "@/common/RouterEndpoints";
 import { t } from "@nerimity/i18lite";
-import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "@/components/ui/settings-block/SettingsBlock";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/input/Input";
 import LegacyModal from "@/components/ui/legacy-modal/LegacyModal";
@@ -181,46 +181,45 @@ export default function SettingsPage() {
         />
       </SettingsBlock>
 
-      <SettingsBlock
-        label={t("servers.settings.welcomeScreen.answers.title")}
-        header={!!question()?.answers.length}
-        icon="forum"
-      >
-        <Button
-          label={t("servers.settings.welcomeScreen.answers.addButton")}
-          iconName="add"
-          iconSize={16}
-          margin={0}
-          onClick={addAnswer}
-        />
-      </SettingsBlock>
-      <For each={answers()}>
-        {(answer, i) => (
-          <SettingsBlock
-            description={roleList(i())}
-            icon="forum"
-            label={answer.title}
-            borderTopRadius={false}
-            borderBottomRadius={i() === question()!.answers.length - 1}
-          >
-            <Button
-              label={t("general.deleteButton")}
-              iconName="delete"
-              iconSize={16}
-              margin={[0, 4]}
-              color="var(--alert-color)"
-              onClick={() => onDeleteClick(i())}
-            />
-            <Button
-              label={t("general.editButton")}
-              iconName="edit"
-              iconSize={16}
-              margin={0}
-              onClick={() => onEditClick(i())}
-            />
-          </SettingsBlock>
-        )}
-      </For>
+      <SettingsGroup>
+        <SettingsBlock
+          label={t("servers.settings.welcomeScreen.answers.title")}
+          icon="forum"
+        >
+          <Button
+            label={t("servers.settings.welcomeScreen.answers.addButton")}
+            iconName="add"
+            iconSize={16}
+            margin={0}
+            onClick={addAnswer}
+          />
+        </SettingsBlock>
+        <For each={answers()}>
+          {(answer, i) => (
+            <SettingsBlock
+              description={roleList(i())}
+              icon="forum"
+              label={answer.title}
+            >
+              <Button
+                label={t("general.deleteButton")}
+                iconName="delete"
+                iconSize={16}
+                margin={[0, 4]}
+                color="var(--alert-color)"
+                onClick={() => onDeleteClick(i())}
+              />
+              <Button
+                label={t("general.editButton")}
+                iconName="edit"
+                iconSize={16}
+                margin={0}
+                onClick={() => onEditClick(i())}
+              />
+            </SettingsBlock>
+          )}
+        </For>
+      </SettingsGroup>
 
       <Show when={error()}>
         <Text color="var(--alert-color)">{error()}</Text>

--- a/src/components/servers/settings/welcome-screen/WelcomeScreen.tsx
+++ b/src/components/servers/settings/welcome-screen/WelcomeScreen.tsx
@@ -3,7 +3,7 @@ import RouterEndpoints from "@/common/RouterEndpoints";
 import { useNavigate, useParams } from "solid-navigator";
 import { For, createSignal, onMount } from "solid-js";
 import useStore from "@/chat-api/store/useStore";
-import SettingsBlock from "@/components/ui/settings-block/SettingsBlock";
+import SettingsBlock, { SettingsGroup } from "@/components/ui/settings-block/SettingsBlock";
 import Button from "@/components/ui/Button";
 
 import {
@@ -77,19 +77,20 @@ export default function SettingsPage() {
         />
         <BreadcrumbItem title={t("servers.settings.drawer.welcome-screen")} />
       </Breadcrumb>
-      <SettingsBlock
-        label={t("servers.settings.welcomeScreen.title")}
-        header={!!questions().length}
-        description={t("servers.settings.welcomeScreen.description")}
-        icon="task_alt"
-      >
-        <Button label={t("servers.settings.welcomeScreen.questions.addButton")} onClick={onAddQuestionClick} />
-      </SettingsBlock>
-      <QuestionList
-        questions={questions()}
-        onEditQuestion={onQuestionEdited}
-        onQuestionDelete={onQuestionDeleted}
-      />
+      <SettingsGroup>
+        <SettingsBlock
+          label={t("servers.settings.welcomeScreen.title")}
+          description={t("servers.settings.welcomeScreen.description")}
+          icon="task_alt"
+        >
+          <Button label={t("servers.settings.welcomeScreen.questions.addButton")} onClick={onAddQuestionClick} />
+        </SettingsBlock>
+        <QuestionList
+          questions={questions()}
+          onEditQuestion={onQuestionEdited}
+          onQuestionDelete={onQuestionDeleted}
+        />
+      </SettingsGroup>
     </div>
   );
 }
@@ -101,12 +102,11 @@ const QuestionList = (props: {
 }) => {
   return (
     <For each={props.questions.sort((a, b) => a.order! - b.order!)}>
-      {(question, i) => (
+      {(question) => (
         <QuestionItem
           question={question}
           onQuestionDelete={() => props.onQuestionDelete(question)}
           onEditQuestion={props.onEditQuestion}
-          isLast={props.questions.length - 1 === i()}
         />
       )}
     </For>
@@ -115,7 +115,6 @@ const QuestionList = (props: {
 
 const QuestionItem = (props: {
   question: RawServerWelcomeQuestion;
-  isLast: boolean;
   onQuestionDelete: () => void;
   onEditQuestion?: (question: RawServerWelcomeQuestion) => void;
 }) => {
@@ -135,8 +134,6 @@ const QuestionItem = (props: {
     <SettingsBlock
       icon="help"
       description={answerList()}
-      borderTopRadius={false}
-      borderBottomRadius={props.isLast}
       label={props.question.title}
     >
       <Button


### PR DESCRIPTION
This is a follow-up to #593; it does the same refactors for the server settings pages.

This might be easier to review with Github's diff settings set to ignore whitespace, since the normal diff handles some of the required indentation changes badly.  (It should be in the settings gear in the top right of the diff view.)

## Did you test your code?
Tested on Chrome on Android & Firefox on Linux.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured settings interface with improved layout and visual organization
  * Enhanced grouping of related settings sections for better clarity

* **Style**
  * Updated spacing and alignment across all settings pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->