### PR TITLE
fix: prevent non-deterministic conflicting block styles

### DIFF
--- a/src/components/servers/settings/invites/styles.module.scss
+++ b/src/components/servers/settings/invites/styles.module.scss
@@ -29,6 +29,8 @@
 }
 
 .inviteItem {
+  display: flex;
+  align-items: center;
   padding-left: 10px;
   gap: 6px;
 

--- a/src/components/settings/ActivityStatus.tsx
+++ b/src/components/settings/ActivityStatus.tsx
@@ -426,6 +426,7 @@ const EditActivityStatusModal = (props: {
             <Show when={showEmojiPicker()}>
               <Block
                 style={{
+                  display: "flex",
                   "margin-top": "-1px",
                   padding: "0",
                 }}

--- a/src/components/ui/settings-block/SettingsBlock.tsx
+++ b/src/components/ui/settings-block/SettingsBlock.tsx
@@ -37,6 +37,7 @@ export default function SettingsBlock(props: BlockProps) {
       state={props.historyState}
       href={props.href}
       class={classNames(
+        styles.settingsBlock,
         styles.block,
         conditionalClass(props.header, styles.header),
         conditionalClass(props.borderTopRadius === false, styles.joinTop),

--- a/src/components/ui/settings-block/styles.module.scss
+++ b/src/components/ui/settings-block/styles.module.scss
@@ -1,13 +1,15 @@
-.block {
-  display: flex;
-  align-items: center;
-  min-height: 40px;
+/* :where() has zero specificity; this allows overriding this rule with
+solid-styled-components styles, which have non-deterministic load order. */
+:where(.block) {
   padding: 10px;
   padding-left: 15px;
   margin-bottom: 5px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.05);
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.4);
+}
+
+.block {
   &.clickable {
     cursor: pointer;
     &:hover {
@@ -24,6 +26,12 @@
     border-bottom-right-radius: 0;
     margin-bottom: 1px;
   }
+}
+
+.settingsBlock {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
 }
 
 .group > .block {


### PR DESCRIPTION
This prevents some non-deterministic style conflicts caused by solid-styled-components styles being inserted in an inconsistent order with respect to other stylesheets.  (For me, they are consistently higher priority than other stylesheets on Firefox, but only 1/3 of the time on Chrome.)

## Screenshots

Without the fix, on Chrome:
<img height="279" alt="image" src="https://github.com/user-attachments/assets/cf000858-7e21-4807-9e0e-a24a48dc992a" />
Also without the fix, on Chrome (may have been a different load order from a recompile????)
<img height="467" alt="image" src="https://github.com/user-attachments/assets/cf40a887-76fb-4f4a-aa47-baf959d3a823" />

With the fix, on Chrome:
<img height="514" alt="image" src="https://github.com/user-attachments/assets/7316618c-8c10-4685-bc00-7989224a02d6" />

(Firefox always prioritizes the solid-styled-components styles, so the fix doesn't seem to be required for it.)

## Did you test your code?
Tested on Firefox & Chrome on desktop and Chrome on Android.

## Additional context
This is actually the same issue as the border radius issue in the mobile bottom pane; that's also a solid-styled-components style that sometimes fails to override the main styles.  (Though that one works on Chrome and fails on Firefox for me...)

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~ (N/A)
- [ ] ~~Any new user-facing strings are properly localized~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout alignment and spacing across settings-related UI components
  * Enhanced visual consistency in settings interface through refined styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->