### PR TITLE
fix: fix specificity for border radius for mobile bottom pane

### DIFF
--- a/src/components/ui/MobileBottomPane.module.scss
+++ b/src/components/ui/MobileBottomPane.module.scss
@@ -26,7 +26,8 @@
   }
 }
 
-.item {
+/* specificity hack to consistently override solid-styled-components styles */
+.item.item {
   display: flex;
 
   flex-direction: column;


### PR DESCRIPTION
This increases the specificity of the item style overrides to more consistently override the existing solid-styled-components styles.  See #597 for more details.

## Screenshots
<img width="460" height="121" alt="image" src="https://github.com/user-attachments/assets/dbbe9947-83d5-4eb2-9187-29b76d863887" />

## Did you test your code?
Tested on Firefox & Chrome on desktop, and Chrome on android.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] Text/content changes support internationalization (i18n)  
- [ ] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Refined CSS styling rules to ensure consistent visual rendering and proper style hierarchy across interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->