### PR TITLE
fix: fall back to en-GB for date formats when language is unsupported

### DIFF
--- a/src/common/date.ts
+++ b/src/common/date.ts
@@ -13,20 +13,21 @@ export const [timeFormat, setTimeFormat] = useLocalStorage<"12hr" | "24hr">(
 
 export const formatters = createMemo(() => {
   const lang = getCurrentLanguageISO();
+  const options = [lang, "en-GB"];
   return {
     duration: {
-      long: new Intl.DurationFormat(lang, {
+      long: new Intl.DurationFormat(options, {
         style: "long"
       }),
-      narrow: new Intl.DurationFormat(lang, {
+      narrow: new Intl.DurationFormat(options, {
         style: "narrow"
       }),
-      narrowForceSeconds: new Intl.DurationFormat(lang, {
+      narrowForceSeconds: new Intl.DurationFormat(options, {
         style: "narrow",
         secondsDisplay: "always"
       }),
       // H:MM:SS or MM:SS
-      digital: new Intl.DurationFormat(lang, {
+      digital: new Intl.DurationFormat(options, {
         style: "narrow",
         hoursDisplay: "auto",
         hours: "numeric",
@@ -34,7 +35,7 @@ export const formatters = createMemo(() => {
         seconds: "2-digit"
       }),
       // H:MM:SS or M:SS
-      digitalShort: new Intl.DurationFormat(lang, {
+      digitalShort: new Intl.DurationFormat(options, {
         style: "narrow",
         hoursDisplay: "auto",
         hours: "numeric",
@@ -43,22 +44,22 @@ export const formatters = createMemo(() => {
       })
     },
     datetime: {
-      longDate: new Intl.DateTimeFormat(lang, {
+      longDate: new Intl.DateTimeFormat(options, {
         dateStyle: "full",
         timeStyle: "short",
         hour12: timeFormat() === "12hr"
       }),
-      mediumDate: new Intl.DateTimeFormat(lang, {
+      mediumDate: new Intl.DateTimeFormat(options, {
         dateStyle: "medium",
         timeStyle: "short",
         hour12: timeFormat() === "12hr"
       }),
-      seconds: new Intl.DateTimeFormat(lang, {
+      seconds: new Intl.DateTimeFormat(options, {
         timeStyle: "medium",
         hour12: timeFormat() === "12hr"
       })
     },
-    relative: new Intl.RelativeTimeFormat(lang, {
+    relative: new Intl.RelativeTimeFormat(options, {
       numeric: "auto"
     })
   };


### PR DESCRIPTION
This sets `en-GB` as the fallback language for datetime formatting, as some older browsers appear not to handle normal fallbacks gracefully.  The specific case was with Belarusian on a Chrome webview version 114, with the system language also being Belarusian.  Chrome 114 doesn't support `be-*` locales, which led to broken duration and date formats:
<img width="537" height="294" alt="image" src="https://github.com/user-attachments/assets/ec76fee8-0420-482b-b69a-b4e0ca43f9e4" />

## Did you test your code?
I tested locally on Chrome 114, but I couldn't fully reproduce the locale fallback issues.  I've also tested with modern Firefox on desktop & modern Chrome on Android, and this doesn't break anything -- the only thing that should change is that `uwu` will now fall back to `en-GB` rather than the system default locale.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced date and time formatting with improved language fallback support, ensuring consistent locale resolution across duration, date, and relative time displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->