### PR TITLE
fix: don't use unicodeSets regex feature, fix gradient transparency

### DIFF
--- a/src/components/Markup.tsx
+++ b/src/components/Markup.tsx
@@ -78,8 +78,16 @@ const sliceText = (
 type CustomEntity = Entity & { type: "custom" };
 
 const TimeOffsetRegex = /^[+-]\d{4}$/;
-const CustomColorExprRegex =
-  /^(?<colors>#(?:\p{Hex_Digit}{3,4}|\p{Hex_Digit}{6,7})(?:-(?:#(?:\p{Hex_Digit}{3,4}|\p{Hex_Digit}{6,7})))+)\s+(?<text>.*)$/v;
+
+const HexColorRegex = /#(?:[a-fA-F0-9]{3,4}|[a-fA-F0-9]{6}|[a-fA-F0-9]{8})/;
+const CustomColorExprRegex = new RegExp(
+  "^(?<colors>" +
+    HexColorRegex.source +
+    "(?:-" +
+    HexColorRegex.source +
+    ")+)" +
+    /\s+(?<text>.*)$/.source
+);
 
 function transformCustomEntity(entity: CustomEntity, ctx: RenderContext) {
   const messages = useMessages();


### PR DESCRIPTION
The unicode sets / "v" flag are only supported since mid 2023; this replaces them with `[a-fA-F0-9]`, which matches the CSS spec. https://caniuse.com/mdn-javascript_builtins_regexp_unicodesets

This also fixes support for 8-character #RRGGBBAA color codes.  (The length was hardcoded as 7.)

## Did you test your code?

I've tested this on desktop Firefox and Chrome on mobile, as well as an older version of Chrome on desktop: 100.0.4896.88-1.1 (which was stuck on a Connecting... screen before this was fixed).

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] ~~Text/content changes support internationalization (i18n)~~
- [x] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradient color parsing to more reliably detect hex colors, preserving existing gradient appearance and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->