### PR TITLE
chore: use color-mix for theme vars when supported

### DIFF
--- a/src/common/themes.ts
+++ b/src/common/themes.ts
@@ -309,17 +309,35 @@ const placeholder = document.createElement("span");
 placeholder.style.display = "none";
 document.body.appendChild(placeholder);
 
-const computedColor = (color: string): [number, number, number, number] => {
+const computedColor = (
+  color: string
+): [number, number, number, number] | null => {
+  placeholder.style.color = "";
   placeholder.style.color = color;
+  if (placeholder.style.color == "") return null;
+
   const computed = window.getComputedStyle(placeholder).color;
-  const match = computed.match(/^rgba?\((.*)\)$/)?.[1] || "0,0,0,0";
-  const colors = match.split(",").map(Number);
+  const match = computed.match(/^rgba?\((.*)\)$/)?.[1];
+  const colors = match?.split(",")?.map(Number);
+  if (colors === undefined || colors.length < 3 || colors.length > 4)
+    return null;
   colors[3] = colors[3] ?? 1.0;
   return colors as [number, number, number, number];
 };
 
+const supportsColorMix = CSS.supports(
+  "color",
+  "color-mix(in srgb, #FFF 50%, transparent)"
+);
+
 const dimmedColor = (color: string, opacity: number): string => {
-  const [r, g, b, a] = computedColor(color);
+  if (supportsColorMix)
+    return `color-mix(in srgb, ${color} ${opacity * 100}%, transparent)`;
+
+  const computed = computedColor(color);
+  if (computed === null) return color;
+
+  const [r, g, b, a] = computed;
   return `rgba(${r},${g},${b},${a * opacity})`;
 };
 


### PR DESCRIPTION
As a follow-up to #600, this uses `color-mix` when it's supported, as it properly handles non-rgb color spaces.  Most browsers added support for oklab/etc at the same time as color-mix, so very few browser versions support those color spaces and don't support color-mix (only Safari 15.4).

This also changes the fallback for when the color can't be parsed to pass the color through unchanged, rather than returning a fully transparent color.  This should hopefully fail more gracefully for 

## Did you test your code?
I've tested this on modern desktop Firefox & Chrome on Android.

I've also tested this on old chrome versions:
- 114 supports color-mix and uses it
- 100 doesn't support color-mix and falls back to the computed color method.

(Note that the testing on chrome 100 relied on #607 to fix an error blocking load... so we already couldn't load on almost any browser old enough not to support color-mix, but now we should have better compatibility.)

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] ~~Text/content changes support internationalization (i18n)~~
- [ ] ~~Any new user-facing strings are properly localized~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color computation robustness with better fallback handling for invalid colors.
  * Enhanced browser compatibility by detecting CSS color-mix support and providing appropriate fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->