### PR TITLE
Remove Palestine checkbox from Profile settings

### DIFF
--- a/src/components/settings/ProfileSettings.tsx
+++ b/src/components/settings/ProfileSettings.tsx
@@ -16,7 +16,6 @@ import Text from "@/components/ui/Text";
 import { css, styled } from "solid-styled-components";
 import {
   getUserDetailsRequest,
-  toggleBadge,
   updateUser,
   UserDetails
 } from "@/chat-api/services/UserService";
@@ -33,8 +32,6 @@ import { useCustomPortal } from "../ui/custom-portal/CustomPortal";
 import { AdvancedMarkupOptions } from "../advanced-markup-options/AdvancedMarkupOptions";
 import { formatMessage } from "../message-pane/MessagePane";
 import { RawUser } from "@/chat-api/RawData";
-import Checkbox from "../ui/Checkbox";
-import { hasBit, USER_BADGES } from "@/chat-api/Bitwise";
 import DropDown from "../ui/drop-down/DropDown";
 import { Fonts } from "@/common/fonts";
 
@@ -64,34 +61,10 @@ export default function ProfileSettings() {
         <BreadcrumbItem href="/app" icon="home" title={t("dashboard.title")} />
         <BreadcrumbItem title={t("settings.drawer.profile")} />
       </Breadcrumb>
-      <PalestineBorder />
       <EditProfilePage />
     </Container>
   );
 }
-
-const PalestineBorder = () => {
-  const store = useStore();
-  const user = () => store.account.user();
-  const hasBorder = () =>
-    hasBit(user()?.badges || 0, USER_BADGES.PALESTINE.bit);
-
-  const onToggle = () => {
-    toggleBadge(USER_BADGES.PALESTINE.bit).then((result) => {
-      store.account.setUser({ badges: result.badges });
-    });
-  };
-
-  return (
-    <SettingsBlock
-      icon="favorite"
-      label={t("settings.account.palestineBorder")}
-      onClick={onToggle}
-    >
-      <Checkbox checked={hasBorder()} />
-    </SettingsBlock>
-  );
-};
 
 const bioBlockStyles = css`
   && {

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -587,7 +587,6 @@
       "botID": "Bot ID",
       "profile": "Profile",
       "profileDescription": "Edit your bio or colours",
-      "palestineBorder": "Add Palestine border to your avatar.",
       "bio": "Bio",
       "bioDescription": "Multiline and markup support",
       "gradientColor1": "Gradient Colour 1",
@@ -640,7 +639,7 @@
       },
       "noticeTitle": "Donations",
       "notice": "Support this project by donating money.",
-      "palestineDescription": "Can be equipped by going to profile settings",
+      "palestineDescription": "Free Palestine🇵🇸",
       "price": "{{price}} Badges",
       "supportMethods": "Support Methods"
     },


### PR DESCRIPTION
## What does this PR do?
- Removes checkbox for Palestine badge from Profile settings

## Screenshots
<img width="927" height="296" alt="image" src="https://github.com/user-attachments/assets/2c430fd2-aaf3-4069-90f4-a69963f9fa3d" />
<img width="161" height="172" alt="image" src="https://github.com/user-attachments/assets/c8e646f7-ea08-486b-b77d-1642c003f12b" />

## Did you test your code?
Yes

## Additional context
The badge description (screenshot 2) is just a placeholder, feel free to change.

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Palestine border avatar customization feature from profile settings. Users will no longer have the option to apply a Palestine border effect to their avatars through the profile settings interface.

* **Documentation**
  * Updated the Palestine badge description text in application translations with new messaging to better communicate the badge's purpose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->