### PR TITLE
i18n: Translate Last Online status

### DIFF
--- a/src/components/user-presence/UserPresence.tsx
+++ b/src/components/user-presence/UserPresence.tsx
@@ -8,7 +8,7 @@ import Icon from "../ui/icon/Icon";
 import { getActivityIconName } from "@/components/activity/Activity";
 import { Tooltip } from "../ui/Tooltip";
 import { formatTimestamp } from "@/common/date";
-
+import { t } from "@nerimity/i18lite";
 import { getActivityType } from "@/common/activityType";
 
 // show full will disable overflow eclipses
@@ -79,7 +79,7 @@ const UserPresence = (props: {
       <Switch fallback={statusDetails()?.name()}>
         <Match when={lastOnlineAt() && !user()?.presence()?.status}>
           <div class={styles.lastOnline}>
-            Last online {formatTimestamp(lastOnlineAt()!)}
+            {t("status.lastOnline", { time: formatTimestamp(lastOnlineAt()!) })}
           </div>
         </Match>
         <Match when={activity()}>

--- a/src/locales/list/en-gb.json
+++ b/src/locales/list/en-gb.json
@@ -156,7 +156,8 @@
     "afk": "Away From Keyboard",
     "dnd": "Do Not Disturb",
     "offline": "Offline",
-    "appearAsOffline": "Appear As Offline"
+    "appearAsOffline": "Appear As Offline",
+    "lastOnline": "Last online {{time}}"
   },
   "sidePane": {
     "home": "Home",


### PR DESCRIPTION
## What does this PR do?
- Translates "Last online" as a presence

## Screenshots
<img width="352" height="302" alt="Screenshot_20260329_211445" src="https://github.com/user-attachments/assets/ac3ffe81-7c08-413d-93b7-6df32479acdc" />

## Did you test your code?
Yes

## Additional context
Sorry about the three other commits, I don't know why but GitHub won't let me discard them

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [x] Text/content changes support internationalization (i18n)  
- [x] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added internationalization support for user presence status messages, enabling the "last online" indicator to be translated and displayed in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->