### PR TITLE
fix: increase z-index of floating emoji picker

### DIFF
--- a/src/components/message-pane/styles.module.scss
+++ b/src/components/message-pane/styles.module.scss
@@ -287,7 +287,7 @@ body .floating.floatingSlowModeIndicator {
 
     &.floatingMessageEmojiPicker {
       position: absolute;
-      z-index: 9999999;
+      z-index: 111111111;
       right: 0;
       bottom: 50px;
       left: 60px;


### PR DESCRIPTION
## What does this PR do?
- increase z-index of floating emoji picker

## Screenshots
<img width="942" height="543" alt="image" src="https://github.com/user-attachments/assets/62c84a3c-fa87-4d24-aa8f-85e18cb525e6" />

## Did you test your code?
Yes, opened the emoji picker and confirmed it now renders above the floating item

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layering of the floating emoji picker in the message pane to ensure it displays correctly over other UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->