### PR TITLE
Added a setting for the new Masqurade feature into the role menu

### DIFF
--- a/src/chat-api/Bitwise.ts
+++ b/src/chat-api/Bitwise.ts
@@ -392,6 +392,12 @@ export const ROLE_PERMISSIONS = {
     bit: 256,
     description: () => "Allow users to mention roles",
     icon: "alternate_email"
+  },
+  MASQUERADE: {
+    name: () => "Masquerade",
+    bit: 512,
+    description: () => "Allow members to change name and avatar per-message",
+    //icon: "alternate_email" // We dont need curently a icon for that because a "normal" user cant use it
   }
 };
 

--- a/src/chat-api/RawData.ts
+++ b/src/chat-api/RawData.ts
@@ -101,6 +101,7 @@ export interface RawMessage {
 
   buttons: RawMessageButton[];
   roleMentions: RawServerRole[];
+  creatorOverrideId?: string | null;
   webhookId?: string;
 }
 

--- a/src/components/message-pane/message-item/MessageItem.tsx
+++ b/src/components/message-pane/message-item/MessageItem.tsx
@@ -336,6 +336,9 @@ const Details = (props: DetailsProps) => {
             : t("message.badge.bot")}
         </div>
       </Show>
+      <Show when={!props.message.webhookId && props.message.creatorOverrideId}>
+        <div class={styles.ownerBadge}>masq</div>
+      </Show>
       <div class={styles.date}>{formatTimestamp(props.message.createdAt)}</div>
       <Show when={props.message.silent}>
         <Tooltip tooltip="Silent" anchor="left">


### PR DESCRIPTION
# Pull Request Template

## What does this PR do?
- It adds the option for the Masquerade permision to the role permisions settings

## Screenshots
<img width="1407" height="925" alt="grafik" src="https://github.com/user-attachments/assets/7b595b5c-f762-4b64-ab65-9fff51fed473" />


## Did you test your code?
I tested it (and it worked fine)

## Additional context
<!-- Any additional information, context, or links to relevant issues. -->

## Checklist
- [x] Changes are clear, concise, and easy to review  
- [x] Code has been tested and works as intended  
- [ ] Text/content changes support internationalization (i18n)  
- [ ] Any new user-facing strings are properly localized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **“Masquerade”** permission option (dedicated access level) to allow per-message name and avatar changes.
* **UI Updates**
  * Message details now show an additional **“masq”** badge for non-webhook messages that include a creator override, making masqueraded messages easier to spot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->